### PR TITLE
Add ability to evaluate multiline statements and blocks in one emacs keystroke

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ the following to your `init.el` may be a good start:
 ```lisp
 (add-hook 'fsharp-mode-hook
  (lambda ()
+   (define-key fsharp-mode-map (kbd "M-'")   'fsharp-eval-block-move)
    (define-key fsharp-mode-map (kbd "M-RET") 'fsharp-eval-region)
    (define-key fsharp-mode-map (kbd "C-SPC") 'fsharp-ac/complete-at-point)))
 ```

--- a/fsharp-mode-indent.el
+++ b/fsharp-mode-indent.el
@@ -151,7 +151,8 @@ as indentation hints, unless the comment character is in column zero."
 
 
 ;(defconst fsharp-blank-or-comment-re "[ \t]*\\($\\|#\\)"
-(defconst fsharp-blank-or-comment-re "[ \t]*\\(//.*\\)?"
+;(defconst fsharp-blank-or-comment-re "[ \t]*\\(//.*\\)?"
+(defconst fsharp-blank-or-comment-re "[ \t]*\\($\\|//.*\\)"
   "Regular expression matching a blank or comment line.")
 
 (defconst fsharp-outdent-re
@@ -1475,6 +1476,50 @@ does not include blank lines, comments, or continuation lines."
     (if (eobp)
         (progn (goto-char start) nil)
       t)))
+
+;; On multiline statements, these operators are often found at the beginning of the line
+(defvar fsharp-infix-operators-that-begin-lines
+  '("%" "&&" "&&&" "||" "|||" "^^^"
+    "\\+" "-" "\\*" "/" "::" ":>" ":\\?" ":\\?>"
+    "<<" "<<<" "<|" "<||" "<|||"
+    ">>" "<<<" "|>" "||>" "|||>"))
+
+(defun fsharp-goto-beyond-multiline-statement ()
+  "Jump after the last statement contiguous to the current one, only
+  jumping over those statements that are indented deeper to the
+  current one, or those starting with an infix operator (i.e. think |>
+  on beginning of line)"
+  (interactive)
+  (let ((indent (current-indentation)))
+    (or (fsharp-goto-statement-below) (forward-line 1))
+    (while (and
+            (or
+             (looking-at (concat "[ \t]*\\(" (mapconcat 'identity fsharp-infix-operators-that-begin-lines "\\|") "\\)"))
+             (> (current-indentation) indent))      ; statement indented further
+            (>= (current-indentation) indent)
+            (not (eobp)))
+      (or (fsharp-goto-statement-below) (forward-line 1)))))
+;;    (if (eobp)
+;;        (fsharp-goto-beyond-final-line)))
+
+(defun fsharp-eval-block-move ()
+  "Send the block to the interactive mode, and move the point to the next
+  block.
+
+  Can evaluate let statements that are nested into top level definitions,
+  or deeper. Can evaluate one-liners. Can evaluate multiline sequences of
+  'piped' statements (|>)"
+  (interactive)
+  (let ((p1) (p2))
+    (fsharp-goto-initial-line)
+    (setq p1 (point))
+    (if (fsharp-statement-opens-block-p)
+        (fsharp-goto-beyond-block)
+        (fsharp-goto-beyond-multiline-statement))
+    (setq p2 (point))
+    (fsharp-eval-region p1 p2))
+  (forward-line -1)
+  (fsharp-goto-statement-below))
 
 (defun fsharp-go-up-tree-to-keyword (key)
   "Go to begining of statement starting with KEY, at or preceding point.

--- a/fsharp-mode-indent.el
+++ b/fsharp-mode-indent.el
@@ -1477,12 +1477,13 @@ does not include blank lines, comments, or continuation lines."
         (progn (goto-char start) nil)
       t)))
 
-;; On multiline statements, these operators are often found at the beginning of the line
-(defvar fsharp-infix-operators-that-begin-lines
+;; On multiline statements, these symbols are often found at the beginning of the line
+(defvar fsharp-tokens-that-cannot-begin-statements
   '("%" "&&" "&&&" "||" "|||" "^^^"
     "\\+" "-" "\\*" "/" "::" ":>" ":\\?" ":\\?>"
     "<<" "<<<" "<|" "<||" "<|||"
-    ">>" "<<<" "|>" "||>" "|||>"))
+    ">>" "<<<" "|>" "||>" "|||>"
+    "|" "and" "done" "then" "else" "with" "finally" "when"))
 
 (defun fsharp-goto-beyond-multiline-statement ()
   "Jump after the last statement contiguous to the current one, only
@@ -1494,7 +1495,7 @@ does not include blank lines, comments, or continuation lines."
     (or (fsharp-goto-statement-below) (forward-line 1))
     (while (and
             (or
-             (looking-at (concat "[ \t]*\\(" (mapconcat 'identity fsharp-infix-operators-that-begin-lines "\\|") "\\)"))
+             (looking-at (concat "[ \t]*\\(" (mapconcat 'identity fsharp-tokens-that-cannot-begin-statements "\\|") "\\)"))
              (> (current-indentation) indent))      ; statement indented further
             (>= (current-indentation) indent)
             (not (eobp)))
@@ -1513,9 +1514,7 @@ does not include blank lines, comments, or continuation lines."
   (let ((p1) (p2))
     (fsharp-goto-initial-line)
     (setq p1 (point))
-    (if (fsharp-statement-opens-block-p)
-        (fsharp-goto-beyond-block)
-        (fsharp-goto-beyond-multiline-statement))
+    (fsharp-goto-beyond-multiline-statement)
     (setq p2 (point))
     (fsharp-eval-region p1 p2))
   (forward-line -1)


### PR DESCRIPTION
Ported from https://github.com/fsharp/fsharpbinding/pull/879

Haven't addressed latest questions from @rneatherway yet.