### PR TITLE
Fix: Not enough arguments for format string.

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -739,7 +739,7 @@ display a short summary in the minibuffer."
             (if fsharp-ac-use-popup
                 (fsharp-ac/show-popup data)
               (fsharp-ac/show-info-window data)))
-        (fsharp-ac-message-safely (fsharp-doc/format-for-minibuffer data))))))
+        (fsharp-ac-message-safely "%s" (fsharp-doc/format-for-minibuffer data))))))
 
 (defun fsharp-ac/show-popup (str)
   (if (display-graphic-p)


### PR DESCRIPTION
Given code like:

```fsharp
let (%) x = x
```

and pointing at `%` gives an error such as:

```
Debugger entered--Lisp error: (error "Not enough arguments for format string")
  message("val ( % ) : x:'a -> 'a")
  apply(message "val ( % ) : x:'a -> 'a" nil)
  fsharp-ac-message-safely("val ( % ) : x:'a -> 'a")
  fsharp-ac-handle-tooltip("val ( % ) : x:'a -> 'a\n\nFull name: Main.( % )")
  fsharp-ac-filter-output(#<process fsharp-complete> "{\"Kind\":\"tooltip\",\"Data\":\"val ( % ) : x:'a -> 'a\\n\\nFull name: Main.( % )\"}\n")
```

The problem is that the format string was missing and the parameter string was interpreted as the format string.