### PR TITLE
Remove BOM from process output

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -678,8 +678,10 @@ around to the start of the buffer."
   (with-current-buffer (process-buffer proc)
     (save-excursion
       (goto-char (process-mark proc))
-      (insert-before-markers str)))
-
+      ;; Remove BOM, if present
+      (insert-before-markers (if (string-prefix-p "\ufeff" str)
+				 (substring str 1)
+			       str))))
   (let ((msg (fsharp-ac--get-msg proc)))
     (while msg
       (let ((kind (gethash "Kind" msg))


### PR DESCRIPTION
Even though the BOM from STDOUT is correctly handled by Emacs, there
is also a BOM present in STDERR. And there is no way to seperate STDOUT
and STDERR:

http://www.gnu.org/software/emacs/manual/html_node/elisp/Output-from-Processes.html

Emacs-devel discussion: https://lists.gnu.org/archive/html/emacs-devel/2015-06/msg00556.html

BTW: There might be timing issues, because I did not run into this problem on my faster system.