### PR TITLE
Fix $(ac_archive) target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ dest_bin  = $(HOME)/.emacs.d/fsharp-mode/bin/
 
 # Building
 
-$(ac_archive): $(bin_d)
-	curl -L "$(ac_url)" -o "$(bin_d)/$(ac_archive)"
+$(ac_archive): | $(bin_d)
+	curl -L "$(ac_url)" -o "$(ac_archive)"
 
 $(ac_exe) : $(bin_d) $(ac_archive)
-	unzip "$(bin_d)/$(ac_archive)" -d "$(bin_d)"
+	unzip "$(ac_archive)" -d "$(bin_d)"
 	touch "$(ac_exe)"
 
 ~/.config/.mono/certs:


### PR DESCRIPTION
Different "curl -o" output name cause rebuilding $(ac_archive) target
each time.

Also define $(bin_d) as order-only-prerequisites to prevent
re-downloading each time $(bin_d) gets a new timestamp (when unziping
the distribution).