### PR TITLE
Fix fsi silent cd

### DIFF
--- a/inf-fsharp-mode.el
+++ b/inf-fsharp-mode.el
@@ -168,7 +168,7 @@ Input and output via buffer `*inferior-fsharp*'."
   (save-excursion
     ;; send location to fsi
     (let* (
-          (name (file-truename (buffer-name (current-buffer))))
+          (name (file-truename (buffer-file-name (current-buffer))))
           (dir (file-name-directory name))
           (line (number-to-string (line-number-at-pos start)))
           (loc (concat "# " line " \"" name "\"\n"))

--- a/inf-fsharp-mode.el
+++ b/inf-fsharp-mode.el
@@ -164,27 +164,26 @@ Input and output via buffer `*inferior-fsharp*'."
 (defun inferior-fsharp-eval-region (start end)
   "Send the current region to the inferior fsharp process."
   (interactive "r")
-  (save-excursion (fsharp-run-process-if-needed))
   (save-excursion
+    (fsharp-run-process-if-needed)
     ;; send location to fsi
-    (let* (
-          (name (file-truename (buffer-file-name (current-buffer))))
-          (dir (file-name-directory name))
-          (line (number-to-string (line-number-at-pos start)))
-          (loc (concat "# " line " \"" name "\"\n"))
-          (movedir (concat "#silentCd @\"" dir "\";;\n")))
+    (let* ((name (file-truename (buffer-file-name (current-buffer))))
+           (dir (file-name-directory name))
+           (line (number-to-string (line-number-at-pos start)))
+           (loc (concat "# " line " \"" name "\"\n"))
+	   (movedir (concat "#silentCd @\"" dir "\";;\n")))
       (comint-send-string inferior-fsharp-buffer-name movedir)
-      (comint-send-string inferior-fsharp-buffer-name loc))
-    (goto-char end)
-    (comint-send-region inferior-fsharp-buffer-name start (point))
-    ;; normally, ";;" are part of the region
-    (if (and (>= (point) 2)
-             (prog2 (backward-char 2) (looking-at ";;")))
-        (comint-send-string inferior-fsharp-buffer-name "\n")
-      (comint-send-string inferior-fsharp-buffer-name "\n;;\n"))
-    ;; the user may not want to see the output buffer
-    (if fsharp-display-when-eval
-        (display-buffer inferior-fsharp-buffer-name t))))
+      (comint-send-string inferior-fsharp-buffer-name loc)))
+  (goto-char end)
+  (comint-send-region inferior-fsharp-buffer-name start (point))
+  ;; normally, ";;" are part of the region
+  (if (and (>= (point) 2)
+	   (prog2 (backward-char 2) (looking-at ";;")))
+      (comint-send-string inferior-fsharp-buffer-name "\n")
+    (comint-send-string inferior-fsharp-buffer-name "\n;;\n"))
+  ;; the user may not want to see the output buffer
+  (if fsharp-display-when-eval
+      (display-buffer inferior-fsharp-buffer-name t)))
 
 (defvar fsharp-previous-output nil
   "tells the beginning of output in the shell-output buffer, so that the


### PR DESCRIPTION
I use this setup for the custom:

    (uniquify-buffer-name-style (quote reverse) nil (uniquify))

which leads to 

     #silentCd    @"c:/cygwin/home/lenny/fsharp/test/src/test/Library.fs/test/src/test/fsharp/lenny/home/cygwin/";;
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

     stdin(1,1): error FS2302: Directory    'c:/cygwin/home/lenny/fsharp/test/src/test/Library.fs/test/src/test/fsharp/lenny/home/cygwin/' doesn't exist

because the _buffer-name_ doesn't match the _buffer-file-name_

I also removed a redundant and nested use of _safe-excursion_

