### PR TITLE
Use fsautocomplete prefix "StartsWith" filter

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -94,7 +94,6 @@ If set to nil, display in a help buffer instead.")
 (defvar fsharp-ac--last-parsed-buffer nil
   "Last parsed BUFFER, so that we reparse if we switch buffers.")
 
-(defvar-local company-prefix nil)
 (defvar-local fsharp-company-callback nil)
 
 (defconst fsharp-ac--log-buf "*fsharp-debug*")

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -351,12 +351,6 @@ For indirect buffers return the truename of the base buffer."
 
 (require 'cl-lib)
 
-(defun fsharp-company-filter (prefix candidates)
-  (if prefix
-    (cl-loop for candidate in candidates
-             when (string-prefix-p prefix candidate 't)
-             collect candidate)))
-
 (defun fsharp-company-candidates (callback)
   (when (eq company-prefix "")
     ;; discard any pending requests as we
@@ -372,13 +366,12 @@ For indirect buffers return the truename of the base buffer."
   (propertize s 'annotation (gethash "GlyphChar" candidate)))
 
 (defun fsharp-ac-completion-done ()
-  (let ((mapped-completion
-    (-map (lambda (candidate)
-            (let ((s (gethash "Name" candidate)))
-              (if (fsharp-ac--isNormalId s) (fsharp-ac-add-annotation-prop s candidate)
-                (s-append "``" (s-prepend "``" (fsharp-ac-add-annotation-prop s candidate))))))
-          fsharp-ac-current-candidate)))
-    (funcall fsharp-company-callback (fsharp-company-filter company-prefix mapped-completion))))
+  (->> (-map (lambda (candidate)
+		    (let ((s (gethash "Name" candidate)))
+		      (if (fsharp-ac--isNormalId s) (fsharp-ac-add-annotation-prop s candidate)
+			(s-append "``" (s-prepend "``" (fsharp-ac-add-annotation-prop s candidate))))))
+		fsharp-ac-current-candidate)
+       (funcall fsharp-company-callback)))
 
 (defun completion-char-p (c)
   "True if the character before the point is a word char or ."

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -233,8 +233,9 @@ For indirect buffers return the truename of the base buffer."
 
 (defun fsharp-ac-send-pos-request (cmd file line col)
   (log-psendstr fsharp-ac-completion-process
-                (format "%s \"%s\" %d %d %d\n" cmd file line col
-                        (* 1000 fsharp-ac-blocking-timeout))))
+                (format "%s \"%s\" %d %d %d %s\n" cmd file line col
+                        (* 1000 fsharp-ac-blocking-timeout)
+			(if (string= cmd "completion") "filter=StartsWith" ""))))
 
 (defun fsharp-ac--process-live-p ()
   "Check whether the background process is live."


### PR DESCRIPTION
This reduces the "fsautocomplete" response size and thus improves elisp
parsing/filtering speed when using the "completion" command.

```company``` completion is much faster now when using modules with many values.

Maybe we can also get rid of ```fsharp-company-filter```?

BTW: Thanks for the company backend. I never looked back to autocomplete.
