### PR TITLE
Unbreak company support on non-graphic displays

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -266,7 +266,9 @@
   ;; In Emacs 24.4 onwards, tell electric-indent-mode that fsharp-mode
   ;; has no deterministic indentation.
   (when (boundp 'electric-indent-inhibit) (setq electric-indent-inhibit t))
-  (when (boundp 'company-quickhelp-mode) (company-quickhelp-mode 1))
+  (when (and (display-graphic-p)
+             (boundp 'company-quickhelp-mode)) ; not supported on ttys
+    (company-quickhelp-mode 1))
 
   (let ((file (buffer-file-name)))
     (when file


### PR DESCRIPTION
`company-quickhelp` uses `pos-tip`, which doesn't support terminals.