### PR TITLE
Fix async timeout no project

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -526,12 +526,6 @@ prevent usage errors being displayed by FSHARP-DOC-MODE."
   (interactive)
   (pop-tag-mark))
 
-(defun fsharp-ac/electric-backspace ()
-  (interactive)
-  (when (eq (char-before) ?.)
-    (ac-stop))
-  (delete-char -1))
-
 (defun fsharp-ac/complete-at-point (&optional quiet)
   (interactive)
   (when (and (fsharp-ac-can-make-request quiet)

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -356,10 +356,12 @@ For indirect buffers return the truename of the base buffer."
     ;; just pressed '.' or are at the start of a new line
     (setq fsharp-ac-status 'idle))
 
-  (when (and (fsharp-ac-can-make-request 't)
+  (if (and (fsharp-ac-can-make-request 't)
              (eq fsharp-ac-status 'idle))
-    (setq fsharp-company-callback callback)
-    (fsharp-ac-make-completion-request)))
+      (progn
+	(setq fsharp-company-callback callback)
+	(fsharp-ac-make-completion-request))
+    (funcall callback nil)))
 
 (defun fsharp-ac-add-annotation-prop (s candidate)
   (propertize s 'annotation (gethash "GlyphChar" candidate)))

--- a/test/Test1/NoProject.fs
+++ b/test/Test1/NoProject.fs
@@ -1,0 +1,3 @@
+module FileTwo
+
+open System.Collection

--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -74,7 +74,6 @@
      (search-forward "X.func")
      (delete-char -3)
      (let ((company-async-timeout 5)) (company-complete))
-     (wait-for-condition (not (null fsharp-ac-current-candidate)))
      (beginning-of-line)
      (should (search-forward "X.func")))))
 

--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -78,6 +78,16 @@
      (beginning-of-line)
      (should (search-forward "X.func")))))
 
+(ert-deftest check-completion-no-project ()
+  "Check completion-at-point if File is not part of a Project."
+  (fsharp-mode-wrapper '("NoProject.fs")
+   (lambda ()
+     (find-file-and-wait-for-project-load "test/Test1/NoProject.fs")
+     (search-forward "open System.Collectio")
+     (company-complete)
+     (beginning-of-line)
+     (should (re-search-forward "open System\\.Collection$" nil t)))))
+
 (ert-deftest check-gotodefn ()
   "Check jump to (and back from) definition works"
   (fsharp-mode-wrapper '("Program.fs")


### PR DESCRIPTION
Fixes completion errors when the current file is not part of a Project:
`
(error "Company: backend fsharp-ac/company-backend async timeout with args (candidates Sys)")
`