### PR TITLE
Faster completions

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -398,7 +398,7 @@ For indirect buffers return the truename of the base buffer."
         (doc-buffer (company-doc-buffer (fsharp-ac-document arg)))))
 
 (defconst fsharp-ac--ident
-  (rx (one-or-more (not (any ".` \t\r\n"))))
+  (rx (one-or-more (not (any ".` ,(\t\r\n"))))
   "Regexp for normal identifiers.")
 
 ; Note that this regexp is not 100% correct.
@@ -432,7 +432,7 @@ For indirect buffers return the truename of the base buffer."
            (or (regexp ,fsharp-ac--ident)
                (regexp ,fsharp-ac--rawIdent))
            "."))
-         (group (zero-or-more (not (any ".` \t\r\n"))))
+         (group (zero-or-more (not (any ".` ,(\t\r\n"))))
          string-end))
   "Regexp for a dotted ident with a standard residue.")
 

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -228,10 +228,11 @@ For indirect buffers return the truename of the base buffer."
 ;;; Display Requests
 
 (defun fsharp-ac-send-pos-request (cmd file line col)
-  (log-psendstr fsharp-ac-completion-process
-                (format "%s \"%s\" %d %d %d %s\n" cmd file line col
-                        (* 1000 fsharp-ac-blocking-timeout)
-      (if (string= cmd "completion") "filter=StartsWith" ""))))
+  (let ((linestr (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+    (log-psendstr fsharp-ac-completion-process
+                  (format "%s \"%s\" \"%s\" %d %d %d %s\n" cmd file linestr line col
+                          (* 1000 fsharp-ac-blocking-timeout)
+                          (if (string= cmd "completion") "filter=StartsWith" "")))))
 
 (defun fsharp-ac--process-live-p ()
   "Check whether the background process is live."
@@ -341,8 +342,9 @@ For indirect buffers return the truename of the base buffer."
   (clrhash fsharp-ac-current-helptext)
   (let ((line (line-number-at-pos)))
     (if (not (eq fsharp-ac-last-parsed-line line))
-        (setq fsharp-ac-last-parsed-line line)
-      (fsharp-ac-parse-current-buffer))
+        (progn
+          (setq fsharp-ac-last-parsed-line line)
+          (fsharp-ac-parse-current-buffer)))
     (fsharp-ac-send-pos-request
      "completion"
      (fsharp-ac--buffer-truename)

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -226,9 +226,8 @@ For indirect buffers return the truename of the base buffer."
 
 ;;; ----------------------------------------------------------------------------
 ;;; Display Requests
-
 (defun fsharp-ac-send-pos-request (cmd file line col)
-  (let ((linestr (buffer-substring-no-properties (line-beginning-position) (line-end-position))))
+  (let ((linestr (replace-regexp-in-string "\"" "\\\""(buffer-substring-no-properties (line-beginning-position) (line-end-position)) t t)))
     (log-psendstr fsharp-ac-completion-process
                   (format "%s \"%s\" \"%s\" %d %d %d %s\n" cmd file linestr line col
                           (* 1000 fsharp-ac-blocking-timeout)

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -498,7 +498,6 @@ on QUIET to FSHARP-AC-CAN-MAKE-REQUEST. This is a bit of hack to
 prevent usage errors being displayed by FSHARP-DOC-MODE."
   (interactive)
   (when (fsharp-ac-can-make-request quiet)
-     (fsharp-ac-parse-current-buffer)
      (fsharp-ac-send-pos-request "tooltip"
                                  (fsharp-ac--buffer-truename)
                                  (line-number-at-pos)
@@ -508,7 +507,6 @@ prevent usage errors being displayed by FSHARP-DOC-MODE."
   "Find the uses in this file of the symbol at point."
   (interactive)
   (when (fsharp-ac-can-make-request)
-    (fsharp-ac-parse-current-buffer)
     (fsharp-ac-send-pos-request "symboluse"
                                 (fsharp-ac--buffer-truename)
                                 (line-number-at-pos)
@@ -518,7 +516,6 @@ prevent usage errors being displayed by FSHARP-DOC-MODE."
   "Find the point of declaration of the symbol at point and goto it."
   (interactive)
   (when (fsharp-ac-can-make-request)
-    (fsharp-ac-parse-current-buffer)
     (fsharp-ac-send-pos-request "finddecl"
                                 (fsharp-ac--buffer-truename)
                                 (line-number-at-pos)

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -362,8 +362,8 @@ For indirect buffers return the truename of the base buffer."
   (if (and (fsharp-ac-can-make-request 't)
              (eq fsharp-ac-status 'idle))
       (progn
-	(setq fsharp-company-callback callback)
-	(fsharp-ac-make-completion-request))
+  (setq fsharp-company-callback callback)
+  (fsharp-ac-make-completion-request))
     (funcall callback nil)))
 
 (defun fsharp-ac-add-annotation-prop (s candidate)
@@ -371,10 +371,10 @@ For indirect buffers return the truename of the base buffer."
 
 (defun fsharp-ac-completion-done ()
   (->> (-map (lambda (candidate)
-		    (let ((s (gethash "Name" candidate)))
-		      (if (fsharp-ac--isNormalId s) (fsharp-ac-add-annotation-prop s candidate)
-			(s-append "``" (s-prepend "``" (fsharp-ac-add-annotation-prop s candidate))))))
-		fsharp-ac-current-candidate)
+        (let ((s (gethash "Name" candidate)))
+          (if (fsharp-ac--isNormalId s) (fsharp-ac-add-annotation-prop s candidate)
+      (s-append "``" (s-prepend "``" (fsharp-ac-add-annotation-prop s candidate))))))
+    fsharp-ac-current-candidate)
        (funcall fsharp-company-callback)))
 
 (defun completion-char-p (c)

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -529,6 +529,7 @@ prevent usage errors being displayed by FSHARP-DOC-MODE."
   (interactive)
   (when (and (fsharp-ac-can-make-request quiet)
              (eq fsharp-ac-status 'idle))
+    (fsharp-ac-parse-current-buffer)
     (company-complete)))
 
 (defun fsharp-ac--parse-current-file ()

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -252,7 +252,7 @@
   (setq company-backends (list 'fsharp-ac/company-backend))
   (setq company-auto-complete 't)
   (setq company-auto-complete-chars ".")
-  (setq company-idle-delay 0.5)
+  (setq company-idle-delay 0.03)
   (setq company-minimum-prefix-length 0)
   (setq company-require-match 'nil)
   (setq company-tooltip-align-annotations 't)


### PR DESCRIPTION
This makes completions faster by not requiring a full parse to complete before issuing completions.

We parse once per line, and subsequent requests send the lineStr to FSAC. Corresponding FSAC PR incoming.