### PR TITLE
prefer exact case sort

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -365,6 +365,23 @@ For indirect buffers return the truename of the base buffer."
   (fsharp-ac-make-completion-request))
     (funcall callback nil)))
 
+(defun fsharp-company-sort-preferring-exact-or-same-case (candidates)
+  (let* ((exact nil)
+        (sameprefix nil)
+        (others nil)
+        (prefix (fsharp-ac-get-prefix))
+        (plen (length prefix)))
+    (mapc (lambda (candidate)
+            (if (equal prefix candidate)
+                (push candidate exact)
+              (if (equal prefix (substring candidate 0 plen))
+                  (push candidate sameprefix)
+                (push candidate others))))
+          candidates)
+    (append exact sameprefix others)))
+
+(add-to-list 'company-transformers #'fsharp-company-sort-preferring-exact-or-same-case)
+
 (defun fsharp-ac-add-annotation-prop (s candidate)
   (propertize s 'annotation (gethash "GlyphChar" candidate)))
 


### PR DESCRIPTION
![prefer-exact-case](https://cloud.githubusercontent.com/assets/667194/14349560/d35bd4e8-fcbb-11e5-820c-5d7afe1e550b.gif)

This fixes a little annoyance I have when using company-mode. It sorts based on the case of the completion.

It doesn't always seem to work, but still seems like an improvement over the current code.