### PR TITLE
Fix check-project-files on Windows

### DIFF
--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -63,7 +63,7 @@
        (maphash (lambda (k _) (add-to-list 'projectfiles k)) fsharp-ac--project-files)
        (should-match "Test1/Program.fs" (s-join "" projectfiles))
        (should-match "Test1/FileTwo.fs" (s-join "" projectfiles))
-       (should-match "Test1/bin/Debug/Test1.exe"
+       (should-match (regexp-quote (convert-standard-filename "Test1/bin/Debug/Test1.exe"))
                      (gethash "Output" (gethash project fsharp-ac--project-data)))))))
 
 (ert-deftest check-completion ()


### PR DESCRIPTION
Need to convert expected filename to an OS filename. Also use
`regexp-quote' because Windows backslash need to be escaped in regular
expressions. Refs #80.