### PR TITLE
Inferior fsi: #silentcd to local directory

### DIFF
--- a/inf-fsharp-mode.el
+++ b/inf-fsharp-mode.el
@@ -167,7 +167,7 @@ Input and output via buffer `*inferior-fsharp*'."
   (fsharp-run-process-if-needed)
     ;; send location to fsi
   (let* ((name (file-truename (buffer-file-name (current-buffer))))
-         (dir (file-name-directory name))
+         (dir (fsharp-ac--localname (file-name-directory name)))
          (line (number-to-string (line-number-at-pos start)))
          (loc (concat "# " line " \"" name "\"\n"))
          (movedir (concat "#silentCd @\"" dir "\";;\n")))


### PR DESCRIPTION
Fixes issue when inferior fsi is started in a Tramp directory. Refs #66.

i.e.: Don't send Tramp names:

```
> 
  #silentCd @"/scp:juergen@p.hoetzel.info:/home/juergen/fsharp/HParser/src/HParser/";;
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

/home/juergen/fsharp/HParser/src/HParser/stdin(1,1): error FS2302: Directory '/scp:juergen@p.hoetzel.info:/home/juergen/fsharp/HParser/src/HParser/' doesn't exist
```