### PR TITLE
Fix completion of type annotated symbols

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -489,7 +489,7 @@ If HOST is nil, check process on local system."
            (or (regexp ,fsharp-ac--ident)
                (regexp ,fsharp-ac--rawIdent))
            "."))
-         (group (zero-or-more (not (any ".` ,(\t\r\n"))))
+         (group (zero-or-more (not (any ":.` ,(\t\r\n"))))
          string-end))
   "Regexp for a dotted ident with a standard residue.")
 

--- a/test/Test1/Program.fs
+++ b/test/Test1/Program.fs
@@ -9,6 +9,10 @@ let val3 = testval.Terrific val2
 
 let val4 : FileTwo.NewObjectType = testval
 
+type Dummy = Foo | Bar
+
+let val5:Dummy = Foo
+
 [<EntryPoint>]
 let main args =
     printfn "Hello %d" val2

--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -77,6 +77,17 @@
      (beginning-of-line)
      (should (search-forward "X.func")))))
 
+(ert-deftest check-completion-type-annotation ()
+  "Check completion-at-point works with type annotation"
+  (fsharp-mode-wrapper '("Program.fs")
+   (lambda ()
+     (find-file-and-wait-for-project-load "test/Test1/Program.fs")
+     (search-forward "val5:Dummy")
+     (delete-char -3)
+     (let ((company-async-timeout 5)) (company-complete))
+     (beginning-of-line)
+     (should (search-forward "val5:Dummy")))))
+
 (ert-deftest check-completion-no-project ()
   "Check completion-at-point if File is not part of a Project."
   (fsharp-mode-wrapper '("NoProject.fs")


### PR DESCRIPTION
Using type annotation without white-space triggers these errors.

First case of failure (wrong replacement):
```
type Dummy = Foo | Bar
let x:D
       ^ complete
->
let Dummy

```
the identifier is also replaced because `fsharp-ac-get-prefix` also matches the text before the colon.

Second case of failure (args-out-of-range error):

```
let dummy:D
           ^complete
->
Debugger entered--Lisp error: (args-out-of-range #("DBNull" 0 6 (annotation "C")) 0 7)
  substring(#("DBNull" 0 6 (annotation "C")) 0 7)

```

this is because the prefix i"dummy:D" is longer than the candidates returned by _fsautocomplete.exe_