### PR TITLE
Don't clobber company-backends

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -248,14 +248,16 @@
   (setq font-lock-defaults '(fsharp-font-lock-keywords))
   (setq syntax-propertize-function 'fsharp--syntax-propertize-function)
   ; Some reasonable defaults for company mode
-  (setq company-backends (list 'fsharp-ac/company-backend))
   (setq company-auto-complete 't)
   (setq company-auto-complete-chars ".")
   (setq company-idle-delay 0.03)
   (setq company-minimum-prefix-length 0)
   (setq company-require-match 'nil)
   (setq company-tooltip-align-annotations 't)
-  
+  (setq company-backends
+        (let ((backends-to-remove '(company-dabbrev company-dabbrev-code company-keywords)))
+              (remove-all #'(lambda (backend) (member backend backends-to-remove)) company-backends)))
+  (add-to-list 'company-backends 'fsharp-ac/company-backend)
 
   ;; Error navigation
   (setq next-error-function 'fsharp-ac/next-error)
@@ -276,6 +278,17 @@
 
   (turn-on-fsharp-doc-mode)
   (run-hooks 'fsharp-mode-hook))
+
+(defun remove-all (predic seq &optional res)
+  "Remove items that could be anywhere inside a nested list"
+  (if (null seq)
+      (reverse res)
+      (cond ((and (not (null (car seq))) (listp (car seq)))
+             (remove-all predic (cdr seq)
+                         (cons (remove-all predic (car seq)) res)))
+            ((funcall predic (car seq))
+             (remove-all predic (cdr seq) res))
+            (t (remove-all predic (cdr seq) (cons (car seq) res))))))
 
 (defun fsharp-mode--load-with-binding (file)
   "Attempt to load FILE using the F# compiler binding.


### PR DESCRIPTION
This is a little more complicated than I expected because company-backends can be a list of lists.

I'm removing `company-dabbrev`, `company-dabbrev-code` and `company-keywords` from `company-backends` when in fsharp-mode instead of just allowing the fsharp backend.

Before (stock spacemacs backends)
```elisp
(fsharp-ac/company-backend company-files company-oddmuse (company-dabbrev-code company-gtags company-etags company-keywords) company-capf company-cmake company-xcode company-clang company-semantic company-eclim company-css company-nxml company-bbdb)
```

After

```elisp
(fsharp-ac/company-backend company-bbdb company-nxml company-css company-eclim company-semantic company-clang company-xcode company-cmake company-capf (company-gtags company-etags) company-oddmuse company-files)
```

/cc @juergenhoetzel 