### PR TITLE
Don't clobber company-backends 2

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -448,7 +448,10 @@ If HOST is nil, check process on local system."
     (interactive (list 'interactive))
     (cl-case command
         (interactive (company-begin-backend 'fsharp-ac/company-backend))
-        (prefix  (fsharp-ac-get-prefix))
+        (prefix  (or (fsharp-ac-get-prefix)
+                     ;; Don't pass to next backend if we are not inside a string or comment
+                     (when (and (not (nth 3 (syntax-ppss))) (not (nth 4 (syntax-ppss))))
+                       'stop)))
         (ignore-case 't)
         (candidates (cons :async 'fsharp-company-candidates))
         (annotation (get-text-property 0 'annotation arg))

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -248,7 +248,7 @@
   (setq font-lock-defaults '(fsharp-font-lock-keywords))
   (setq syntax-propertize-function 'fsharp--syntax-propertize-function)
   ; Some reasonable defaults for company mode
-  (setq company-backends (list 'fsharp-ac/company-backend))
+  (add-to-list 'company-backends 'fsharp-ac/company-backend)
   (setq company-auto-complete 't)
   (setq company-auto-complete-chars ".")
   (setq company-idle-delay 0.03)


### PR DESCRIPTION
Based on knowledge gained from  [Don't clobber company-backends](https://github.com/fsharp/emacs-fsharp-mode/pull/84):

- Don't restrict `company-backends` to `fsharp-ac/company-backend`, because users might have setup other useful backends
- Restrict the use of other backends to strings and comments