### PR TITLE
another fix for fsharp-end-of-block

### DIFF
--- a/fsharp-mode-indent.el
+++ b/fsharp-mode-indent.el
@@ -1610,15 +1610,18 @@ This tells add-log.el how to find the current function/method/variable."
   "Move point to the end of the current top-level block"
   (interactive)
   (forward-line 1)
-  (beginning-of-line)
-  (condition-case nil
-      (progn (re-search-forward "^[a-zA-Z#0-9(\[]")
-             (while (continuation-p)
-               (forward-line 1))
-             (forward-line -1))
-    (error
-     (progn (goto-char (point-max)))))
-  (end-of-line))
+  (if (not (eobp))
+      (progn
+        (beginning-of-line)
+        (condition-case nil
+            (progn (re-search-forward "^[a-zA-Z#0-9([]")
+                   (while (continuation-p)
+                     (forward-line 1))
+                   (forward-line -1))
+          (error
+           (progn (goto-char (point-max)))))
+        (end-of-line))
+    (goto-char (point-max))))
 
 (provide 'fsharp-mode-indent)
 


### PR DESCRIPTION
I removed "\" from regex, it seems escaping is not needed here and doesn't escape anything.

Works on the last line in a file now, too. See comment https://github.com/fsharp/emacs-fsharp-mode/issues/92#issuecomment-248735553