### PR TITLE
Dont change `company-minimum-prefix-length'

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -424,10 +424,11 @@ If HOST is nil, check process on local system."
     (interactive (list 'interactive))
     (cl-case command
         (interactive (company-begin-backend 'fsharp-ac/company-backend))
-        (prefix  (or (fsharp-ac-get-prefix)
-                     ;; Don't pass to next backend if we are not inside a string or comment
-                     (when (and (not (nth 3 (syntax-ppss))) (not (nth 4 (syntax-ppss))))
-                       'stop)))
+        (prefix  (when (not (company-in-string-or-comment))
+		     ;; Don't pass to next backend if we are not inside a string or comment
+		     (-if-let (prefix (fsharp-ac-get-prefix))
+			 (cons prefix t)
+		       'stop)))
         (ignore-case t)
         (sorted t)
         (candidates (cons :async 'fsharp-company-candidates))

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -217,7 +217,6 @@
           company-auto-complete
           company-auto-complete-chars
           company-idle-delay
-          company-minimum-prefix-length
           company-require-match
           company-tooltip-align-annotations
           fsharp-ac-last-parsed-ticks
@@ -253,7 +252,6 @@
   (setq company-auto-complete 't)
   (setq company-auto-complete-chars ".")
   (setq company-idle-delay 0.03)
-  (setq company-minimum-prefix-length 0)
   (setq company-require-match 'nil)
   (setq company-tooltip-align-annotations 't)
 


### PR DESCRIPTION
Instead return (prefix . t) in prefix command to let company-mode accept
prefix lengths less than `company-minimum-prefix-length'.

This prevents premature completion of other backends (like dabbrev).

Refs #102 and #101.