### PR TITLE
Don't send trailing newline to fsautocomplete

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -140,7 +140,7 @@ since the last request."
         (fsharp-ac--log (format "Parsing \"%s\"\n" file))
         (process-send-string
          (fsharp-ac-completion-process (fsharp-ac--hostname file))
-         (format "parse \"%s\" %s\n%s\n<<EOF>>\n"
+         (format "parse \"%s\" %s\n%s<<EOF>>\n"
                  (fsharp-ac--localname file)
                  (if force-sync " sync" "")
                  (buffer-substring-no-properties (point-min) (point-max)))))

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -227,7 +227,7 @@
         local-abbrev-table       fsharp-mode-abbrev-table
         paragraph-start          (concat "^$\\|" page-delimiter)
         paragraph-separate       paragraph-start
-        require-final-newline    t
+        require-final-newline    'visit-save
         indent-tabs-mode         nil
         comment-start            "//"
         comment-end              ""


### PR DESCRIPTION
This fixes invalid flycheck lint messages about trailing whitespace.

![empty-line](https://cloud.githubusercontent.com/assets/52547/19531366/b84c4c4e-9637-11e6-8dcd-472adb873357.png)
