### PR TITLE
Dont change default indent region function

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -222,9 +222,7 @@
           fsharp-ac-last-parsed-ticks
           fsharp-ac-errors))
 
-  (setq major-mode               'fsharp-mode
-        mode-name                "fsharp"
-        local-abbrev-table       fsharp-mode-abbrev-table
+  (setq local-abbrev-table       fsharp-mode-abbrev-table
         paragraph-start          (concat "^$\\|" page-delimiter)
         paragraph-separate       paragraph-start
         require-final-newline    'visit-save

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -208,6 +208,7 @@
           comment-column
           comment-start-skip
           parse-sexp-ignore-comments
+          indent-region-function
           indent-line-function
           add-log-current-defun-function
           underline-minimum-offset


### PR DESCRIPTION
 Instead make `indent-region-function` local in fsharp-mode buffers.

Fixes #107
