### PR TITLE
Fix Flycheck; don't busy wait in fsharp-doc-mode

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -219,9 +219,7 @@
           company-auto-complete-chars
           company-idle-delay
           company-require-match
-          company-tooltip-align-annotations
-          fsharp-ac-last-parsed-ticks
-          fsharp-ac-errors))
+          company-tooltip-align-annotations))
 
   (setq local-abbrev-table       fsharp-mode-abbrev-table
         paragraph-start          (concat "^$\\|" page-delimiter)
@@ -266,8 +264,8 @@
       (setq compile-command (fsharp-mode-choose-compile-command file))
       (fsharp-mode--load-with-binding file)))
 
-  (turn-on-fsharp-doc-mode)
   (flycheck-mode 1)
+  (turn-on-fsharp-doc-mode)
   (run-hooks 'fsharp-mode-hook))
 
 (defun fsharp-mode--load-with-binding (file)


### PR DESCRIPTION
Flycheck's idle timer will attempt to check the buffer after a change, and it
requires its callback to be called when it does this.  We were not respecting
this fully, which caused Flycheck to stall/break.  The bug was due to an
interaction between the echo area typesig/symboluse lookups and Flycheck
attempting to perform a check for which it would never get a reply.  The issue
was that Flycheck tries to run a check via post-command-hook, so if the user
merely moved the cursor but did not enter text, Flycheck would try to run a
check and never get a reply because fsharp-ac-parse-current-buffer would
decide to not send anything to FSAC (it only runs if the buffer's tick has
changed or if fsharp-ac--last-parsed-buffer is not the current buffer).  As a
result, there would be no Flycheck-related output for the FSAC process filter to
read, and Flycheck's callback wouldn't get called.