### PR TITLE
A little more tidying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+## Upcoming
+Features
+- #116: Improve Active Pattern font locking, eval-when-compile the main font-lock-keywords form
+- #114: Clean up font-locking code
+
 ## 1.9.3 (2016-10-31)
 Features
-  - #111: Update to FsAutoComplete 0.30.2 
+  - #111: Update to FsAutoComplete 0.30.2
   - #109: Define inferior-fsharp-mode as variant of comint mode
-  
+
 Bugfixes:
   - #110: Dont change default indent region function
   - #105: Don't send trailing newline to fsautocomplete
@@ -210,4 +215,3 @@ Bugfixes:
   - #571: Correct range-check for emacs support
   - #572: Ensure fsi prompt is readonly
   - #452: Fetch SSL certs before building exe in emacs dir
-

--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -63,6 +63,11 @@ with initial value INITVALUE and optional DOCSTRING."
   `(eval-and-compile
      (defvar ,sym ,init ,docstring)))
 
+(def-fsharp-compiled-var fsharp-shebang-regexp
+  "\\(^#!.*?\\)\\([A-Za-z0-9_-]+\\)$"
+  "Capture the #! and path of a shebag in one group and the
+  executable in another.")
+
 (def-fsharp-compiled-var fsharp-access-control-regexp
   "private\\s-+\\|internal\\s-+\\|public\\s-+"
   "Match `private', `internal', or `public', followed by a space,
@@ -194,7 +199,7 @@ with initial value INITVALUE and optional DOCSTRING."
 
 ;; Preprocessor directives (3.3)
 (def-fsharp-compiled-var fsharp-ui-preproessor-directives
-  '("#if" "#else" "#endif"))
+  '("#if" "#else" "#endif" "#light"))
 
 ;; Compiler directives (12.4)
 (def-fsharp-compiled-var fsharp-ui-compiler-directives
@@ -268,8 +273,10 @@ with initial value INITVALUE and optional DOCSTRING."
 (defconst fsharp-font-lock-keywords
   (eval-when-compile
     `((,fsharp-ui-word-list-regexp 0 font-lock-keyword-face)
-      ;; control
-
+      ;; shebang
+      (,fsharp-shebang-regexp
+       (1 font-lock-comment-face)
+       (2 font-lock-keyword-face))
       ;; attributes
       (,fsharp-attributes-regexp . font-lock-preprocessor-face)
       ;; ;; type defines

--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -57,36 +57,42 @@
   "Face for errors"
   :group 'fsharp-ui)
 
-(defconst fsharp-access-control-regexp
+(defmacro def-fsharp-compiled-var (sym init &optional docstring)
+  "Defines a SYMBOL as a constant inside an eval-and-compile form
+with initial value INITVALUE and optional DOCSTRING."
+  `(eval-and-compile
+     (defvar ,sym ,init ,docstring)))
+
+(def-fsharp-compiled-var fsharp-access-control-regexp
   "private\\s-+\\|internal\\s-+\\|public\\s-+"
   "Match `private', `internal', or `public', followed by a space,
   with no capture.")
 
-(defconst fsharp-access-control-regexp-noncapturing
+(def-fsharp-compiled-var fsharp-access-control-regexp-noncapturing
   (format "\\(?:%s\\)" fsharp-access-control-regexp)
   "Same as `fsharp-access-control-regexp', but captures")
 
-(defconst fsharp-inline-rec-regexp
+(def-fsharp-compiled-var fsharp-inline-rec-regexp
   "inline\\s-+\\|rec\\s-+"
   "Match `inline' or `rec', followed by a space.")
 
-(defconst fsharp-inline-rec-regexp-noncapturing
+(def-fsharp-compiled-var fsharp-inline-rec-regexp-noncapturing
   (format "\\(?:%s\\)" fsharp-inline-rec-regexp)
   "Match `inline' or `rec', followed by a space, with no capture.")
 
-(defconst fsharp-valid-identifier-regexp
+(def-fsharp-compiled-var fsharp-valid-identifier-regexp
   "[A-Za-z0-9_']+"
   "Match a normal, valid F# identifier -- alphanumeric characters
   plus ' and underbar. Does not capture")
 
-(defconst fsharp-function-def-regexp
+(def-fsharp-compiled-var fsharp-function-def-regexp
   (concat "\\<\\(?:let\\|and\\|with\\)\\s-+"
           fsharp-inline-rec-regexp-noncapturing
           (format "\\(%s\\)" fsharp-valid-identifier-regexp)
           "\\(?:\\s-+[A-Za-z_]\\|\\s-*(\\)" ;; matches function arguments or open-paren; unclear why 0-9 not in class
           ))
 
-(defconst fsharp-pattern-function-regexp
+(def-fsharp-compiled-var fsharp-pattern-function-regexp
   (concat "\\<\\(?:let\\|and\\)\\s-+"
           fsharp-inline-rec-regexp-noncapturing
           (format "\\(%s\\)" fsharp-valid-identifier-regexp)
@@ -95,14 +101,14 @@
 
 ;; Note that this regexp is used for iMenu. To font-lock active patterns, we
 ;; need to use an anchored match in fsharp-font-lock-keywords.
-(defconst fsharp-active-pattern-regexp
+(def-fsharp-compiled-var fsharp-active-pattern-regexp
   "\\<\\(?:let\\|and\\)\\s-+\\(?:\\(?:inline\\|rec\\)\\s-+\\)?(\\(|[A-Za-z0-9_'|]+|\\))\\(?:\\s-+[A-Za-z_]\\|\\s-*(\\)")
 
-(defconst fsharp-member-access-regexp
+(def-fsharp-compiled-var fsharp-member-access-regexp
   "\\<\\(?:override\\|member\\|abstract\\)\\s-+"
   "Matches members declarations and modifiers on classes.")
 
-(defconst fsharp-member-function-regexp
+(def-fsharp-compiled-var fsharp-member-function-regexp
   (concat fsharp-member-access-regexp
           "\\(?:\\(?:inline\\|rec\\)\\s-+\\)?\\(?:"
           fsharp-valid-identifier-regexp
@@ -111,29 +117,29 @@
           "\\)")
   "Captures the final identifier in a member function declaration.")
 
-(defconst fsharp-overload-operator-regexp
+(def-fsharp-compiled-var fsharp-overload-operator-regexp
   (concat fsharp-member-access-regexp
           "\\(?:\\(?:inline\\|rec\\)\\s-+\\)?\\(([!%&*+-./<=>?@^|~]+)\\)")
   "Match operators when overloaded by a type/class.")
 
-(defconst fsharp-constructor-regexp
+(def-fsharp-compiled-var fsharp-constructor-regexp
   "^\\s-*\\<\\(new\\) *(.*)[^=]*="
   "Matches the `new' keyword in a constructor")
 
-(defconst fsharp-type-def-regexp
+(def-fsharp-compiled-var fsharp-type-def-regexp
   (concat "^\\s-*\\<\\(?:type\\|inherit\\)\\s-+"
           fsharp-access-control-regexp "*" ;; match access control 0 or more times
           "\\([A-Za-z0-9_'.]+\\)"))
 
-(defconst fsharp-var-or-arg-regexp
+(def-fsharp-compiled-var fsharp-var-or-arg-regexp
   "\\_<\\([A-Za-z_][A-Za-z0-9_']*\\)\\_>")
 
-(defconst fsharp-explicit-field-regexp
+(def-fsharp-compiled-var fsharp-explicit-field-regexp
   (concat "^\\s-*\\(?:val\\|abstract\\)\\s-*\\(?:mutable\\s-+\\)?"
           fsharp-access-control-regexp "*" ;; match access control 0 or more times
           "\\([A-Za-z_][A-Za-z0-9_']*\\)\\s-*:\\s-*\\([A-Za-z_][A-Za-z0-9_'<> \t]*\\)"))
 
-(defconst fsharp-attributes-regexp
+(def-fsharp-compiled-var fsharp-attributes-regexp
   "\\[<[A-Za-z0-9_]+>\\]"
   "Match attributes like [<EntryPoint>]")
 
@@ -142,26 +148,21 @@
 ;; structural significance.
 ;;
 ;; In particular:
-;; (| ... |)                 -- banana clips for Active Patterns
+;; (| ... |)                 -- banana clips for Active Patterns (handled separately)
 ;; <@ ... @> and <@@ ... @@> -- quoted expressions
 ;; <| and |>                 -- left and right pipe (also <||, <|||, ||>, |||>)
 ;; << and >>                 -- function composition
 ;; |                         -- match / type expressions
 
-
-(defconst fsharp-operator-active-pattern-regexp
-  "\\((|\\)\\(?:.*\\)\\(|)\\)"
-  "Font lock the banana clips in active patterns.")
-
-(defconst fsharp-operator-quote-regexp
+(def-fsharp-compiled-var fsharp-operator-quote-regexp
   "\\(<@\\{1,2\\}\\)\\(?:.*\\)\\(@\\{1,2\\}>\\)"
   "Font lock <@/<@@ and @>/@@> operators.")
 
-(defconst fsharp-operator-pipe-regexp
+(def-fsharp-compiled-var fsharp-operator-pipe-regexp
   "<|\\{1,3\\}\\||\\{1,3\\}>"
   "Match the full range of pipe operators -- |>, ||>, |||>, etc.")
 
-(defconst fsharp-operator-case-regexp
+(def-fsharp-compiled-var fsharp-operator-case-regexp
   "\\s-*\\(|\\)[A-Za-z0-9_' ]"
   "Match literal | in contexts like match and type declarations.")
 
@@ -182,40 +183,38 @@
 
 (add-hook 'fsharp-mode-hook #'fsharp-imenu-load-index)
 
-(defvar fsharp-var-pre-form
-  (lambda ()
-    (save-excursion
-      (re-search-forward "\\(:\\s-*\\w[^)]*\\)?=" nil t)
-      (match-beginning 0))))
+(defun fsharp-var-pre-form ()
+  (save-excursion
+    (re-search-forward "\\(:\\s-*\\w[^)]*\\)?=" nil t)
+    (match-beginning 0)))
 
-(defvar fsharp-fun-pre-form
-  (lambda ()
-    (save-excursion
-      (search-forward "->"))))
+(defun fsharp-fun-pre-form ()
+  (save-excursion
+    (search-forward "->")))
 
 ;; Preprocessor directives (3.3)
-(defvar fsharp-ui-preproessor-directives
+(def-fsharp-compiled-var fsharp-ui-preproessor-directives
   '("#if" "#else" "#endif"))
 
 ;; Compiler directives (12.4)
-(defvar fsharp-ui-compiler-directives
+(def-fsharp-compiled-var fsharp-ui-compiler-directives
   '("#nowarn" "#load" "#r" "#reference" "#I"
     "#Include" "#q" "#quit" "#time" "#help"))
 
 ;; Lexical matters (18.4)
-(defvar fsharp-ui-lexical-matters
+(def-fsharp-compiled-var fsharp-ui-lexical-matters
   '("#indent"))
 
 ;; Line Directives (3.9)
-(defvar fsharp-ui-line-directives
+(def-fsharp-compiled-var fsharp-ui-line-directives
   '("#line"))
 
 ;; Identifier replacements (3.11)
-(defvar fsharp-ui-identifier-replacements
+(def-fsharp-compiled-var fsharp-ui-identifier-replacements
   '("__SOURCE_DIRECTORY__" "__SOURCE_FILE__" "__LINE__"))
 
 ;; F# keywords (3.4)
-(defvar fsharp-ui-fsharp-threefour-keywords
+(def-fsharp-compiled-var fsharp-ui-fsharp-threefour-keywords
   '("abstract" "and" "as" "assert" "base" "begin"
     "class" "default" "delegate" "do" "do!" "done"
     "downcast" "downto" "elif" "else" "end"
@@ -230,11 +229,11 @@
     "when" "while" "with" "yield" "yield!"))
 
 ;; "Reserved because they are reserved in OCaml"
-(defvar fsharp-ui-ocaml-reserved-words
+(def-fsharp-compiled-var fsharp-ui-ocaml-reserved-words
   '("asr" "land" "lor" "lsl" "lsr" "lxor" "mod" "sig"))
 
 ;; F# reserved words for future use
-(defvar fsharp-ui-reserved-words
+(def-fsharp-compiled-var fsharp-ui-reserved-words
   '("atomic" "break" "checked" "component" "const"
     "constraint" "constructor" "continue" "eager"
     "event" "external" "fixed" "functor" "include"
@@ -249,10 +248,11 @@
 ;;
 ;; Workflows not yet handled by fsautocomplete but async
 ;; always present
-(defvar fsharp-ui-async-words
-  '("async"))
+(def-fsharp-compiled-var fsharp-ui-async-words
+  '("async")
+  "Just the word async, in a list.")
 
-(defconst fsharp-ui-word-list-regexp
+(def-fsharp-compiled-var fsharp-ui-word-list-regexp
   (regexp-opt
    `(,@fsharp-ui-async-words
      ,@fsharp-ui-compiler-directives
@@ -266,60 +266,59 @@
    'symbols))
 
 (defconst fsharp-font-lock-keywords
-  `((,fsharp-ui-word-list-regexp 0 font-lock-keyword-face)
-    ;; control
+  (eval-when-compile
+    `((,fsharp-ui-word-list-regexp 0 font-lock-keyword-face)
+      ;; control
 
-    ;; attributes
-    (,fsharp-attributes-regexp . font-lock-preprocessor-face)
-    ;; ;; type defines
-    (,fsharp-type-def-regexp 1 font-lock-type-face)
-    (,fsharp-function-def-regexp 1 font-lock-function-name-face)
-    (,fsharp-pattern-function-regexp 1 font-lock-function-name-face)
-    ;; (,fsharp-active-pattern-regexp 1 font-lock-function-name-face)
-    ("(|" (0 'fsharp-ui-operator-face)
-     ("\\([A-Za-z'_]+\\)\\(|)?\\)" nil nil
-      (1 font-lock-function-name-face)
-      (2 'fsharp-ui-operator-face)))
-    (,fsharp-member-function-regexp 1 font-lock-function-name-face)
-    (,fsharp-overload-operator-regexp 1 font-lock-function-name-face)
-    (,fsharp-constructor-regexp 1 font-lock-function-name-face)
-    (,fsharp-operator-active-pattern-regexp  (1 'fsharp-ui-operator-face)
-                                             (2 'fsharp-ui-operator-face))
-    (,fsharp-operator-case-regexp 1 'fsharp-ui-operator-face)
-    (,fsharp-operator-pipe-regexp . 'fsharp-ui-operator-face)
+      ;; attributes
+      (,fsharp-attributes-regexp . font-lock-preprocessor-face)
+      ;; ;; type defines
+      (,fsharp-type-def-regexp 1 font-lock-type-face)
+      (,fsharp-function-def-regexp 1 font-lock-function-name-face)
+      (,fsharp-pattern-function-regexp 1 font-lock-function-name-face)
+      ;; (,fsharp-active-pattern-regexp 1 font-lock-function-name-face)
+      ("(|" (0 'fsharp-ui-operator-face)
+       ("\\([A-Za-z'_]+\\)\\(|)?\\)" nil nil
+        (1 font-lock-function-name-face)
+        (2 'fsharp-ui-operator-face)))
+      (,fsharp-member-function-regexp 1 font-lock-function-name-face)
+      (,fsharp-overload-operator-regexp 1 font-lock-function-name-face)
+      (,fsharp-constructor-regexp 1 font-lock-function-name-face)
+      (,fsharp-operator-case-regexp 1 'fsharp-ui-operator-face)
+      (,fsharp-operator-pipe-regexp . 'fsharp-ui-operator-face)
 
-    (,fsharp-operator-quote-regexp  (1 'fsharp-ui-operator-face)
-                                    (2 'fsharp-ui-operator-face))
-    ("[^:]:\\s-*\\(\\<[A-Za-z0-9_' ]*[^ ;\n,)}=<-]\\)\\(<[^>]*>\\)?"
-     (1 font-lock-type-face)
-     ;; 'prevent generic type arguments from being rendered in variable face
-     (2 'fsharp-ui-generic-face nil t))
-    (,(format "^\\s-*\\<\\(let\\|use\\|override\\|member\\|and\\|\\(?:%snew\\)\\)\\_>"
-              (concat fsharp-access-control-regexp "*"))
-     (0 font-lock-keyword-face) ; let binding and function arguments
-     (,fsharp-var-or-arg-regexp
-      (,fsharp-var-pre-form) nil
-      (1 font-lock-variable-name-face nil t)))
-    ("\\<fun\\>"
-     (0 font-lock-keyword-face) ; lambda function arguments
-     (,fsharp-var-or-arg-regexp
-      (,fsharp-fun-pre-form) nil
-      (1 font-lock-variable-name-face nil t)))
-    (,fsharp-type-def-regexp
-     (0 'font-lock-keyword-face) ; implicit constructor arguments
-     (,fsharp-var-or-arg-regexp
-      (,fsharp-var-pre-form) nil
-      (1 font-lock-variable-name-face nil t)))
-    (,fsharp-explicit-field-regexp
-     (1 font-lock-variable-name-face)
-     (2 font-lock-type-face))
+      (,fsharp-operator-quote-regexp  (1 'fsharp-ui-operator-face)
+                                      (2 'fsharp-ui-operator-face))
+      ("[^:]:\\s-*\\(\\<[A-Za-z0-9_' ]*[^ ;\n,)}=<-]\\)\\(<[^>]*>\\)?"
+       (1 font-lock-type-face)
+       ;; 'prevent generic type arguments from being rendered in variable face
+       (2 'fsharp-ui-generic-face nil t))
+      (,(format "^\\s-*\\<\\(let\\|use\\|override\\|member\\|and\\|\\(?:%snew\\)\\)\\_>"
+                (concat fsharp-access-control-regexp "*"))
+       (0 font-lock-keyword-face) ; let binding and function arguments
+       (,fsharp-var-or-arg-regexp
+        (fsharp-var-pre-form) nil
+        (1 font-lock-variable-name-face nil t)))
+      ("\\<fun\\>"
+       (0 font-lock-keyword-face) ; lambda function arguments
+       (,fsharp-var-or-arg-regexp
+        (fsharp-fun-pre-form) nil
+        (1 font-lock-variable-name-face nil t)))
+      (,fsharp-type-def-regexp
+       (0 'font-lock-keyword-face) ; implicit constructor arguments
+       (,fsharp-var-or-arg-regexp
+        (fsharp-var-pre-form) nil
+        (1 font-lock-variable-name-face nil t)))
+      (,fsharp-explicit-field-regexp
+       (1 font-lock-variable-name-face)
+       (2 font-lock-type-face))
 
-    ;; open namespace
-    ("\\<open\s\\([A-Za-z0-9_.]+\\)" 1 font-lock-type-face)
+      ;; open namespace
+      ("\\<open\s\\([A-Za-z0-9_.]+\\)" 1 font-lock-type-face)
 
-    ;; module/namespace
-    ("\\_<\\(?:module\\|namespace\\)\s\\([A-Za-z0-9_.]+\\)" 1 font-lock-type-face)
-    ))
+      ;; module/namespace
+      ("\\_<\\(?:module\\|namespace\\)\s\\([A-Za-z0-9_.]+\\)" 1 font-lock-type-face)
+      )))
 
 (defun fsharp-ui-setup-font-lock ()
   "Set up font locking for F# Mode."

--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -133,7 +133,7 @@ with initial value INITVALUE and optional DOCSTRING."
 
 (def-fsharp-compiled-var fsharp-type-def-regexp
   (concat "^\\s-*\\<\\(?:type\\|inherit\\)\\s-+"
-          fsharp-access-control-regexp "*" ;; match access control 0 or more times
+          fsharp-access-control-regexp-noncapturing "*" ;; match access control 0 or more times
           "\\([A-Za-z0-9_'.]+\\)"))
 
 (def-fsharp-compiled-var fsharp-var-or-arg-regexp
@@ -141,7 +141,7 @@ with initial value INITVALUE and optional DOCSTRING."
 
 (def-fsharp-compiled-var fsharp-explicit-field-regexp
   (concat "^\\s-*\\(?:val\\|abstract\\)\\s-*\\(?:mutable\\s-+\\)?"
-          fsharp-access-control-regexp "*" ;; match access control 0 or more times
+          fsharp-access-control-regexp-noncapturing "*" ;; match access control 0 or more times
           "\\([A-Za-z_][A-Za-z0-9_']*\\)\\s-*:\\s-*\\([A-Za-z_][A-Za-z0-9_'<> \t]*\\)"))
 
 (def-fsharp-compiled-var fsharp-attributes-regexp

--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -92,14 +92,14 @@ with initial value INITVALUE and optional DOCSTRING."
 
 (def-fsharp-compiled-var fsharp-function-def-regexp
   (concat "\\<\\(?:let\\|and\\|with\\)\\s-+"
-          fsharp-inline-rec-regexp-noncapturing
+          fsharp-inline-rec-regexp-noncapturing "?"
           (format "\\(%s\\)" fsharp-valid-identifier-regexp)
           "\\(?:\\s-+[A-Za-z_]\\|\\s-*(\\)" ;; matches function arguments or open-paren; unclear why 0-9 not in class
           ))
 
 (def-fsharp-compiled-var fsharp-pattern-function-regexp
   (concat "\\<\\(?:let\\|and\\)\\s-+"
-          fsharp-inline-rec-regexp-noncapturing
+          fsharp-inline-rec-regexp-noncapturing "?"
           (format "\\(%s\\)" fsharp-valid-identifier-regexp)
           "\\s-*=\\s-*function")
   "Matches an implicit matcher, eg let foo m = function | \"cat\" -> etc.")

--- a/test/apps/FQuake3/NativeMappings.fs.faceup
+++ b/test/apps/FQuake3/NativeMappings.fs.faceup
@@ -220,7 +220,7 @@ Copyright (C) 1999-2005 Id Software, Inc.
         }
 
 «k:module» «t:Md3» =
-    «k:let» «v:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<md3Header_t>») =
+    «k:let» «f:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<md3Header_t>») =
         «k:let» «k:mutable» «v:native» = NativePtr.read ptr
 
         «k:let» «v:hash» = NativePtr.toNativeInt ptr
@@ -236,7 +236,7 @@ Copyright (C) 1999-2005 Id Software, Inc.
         md3
 
 «k:module» «t:DirectoryInfo» =
-    «k:let» «v:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<directory_t>») =
+    «k:let» «f:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<directory_t>») =
         «k:let» «k:mutable» «v:native» = NativePtr.read ptr
 
         «k:let» «v:path» = NativePtr.toStringAnsi &&native.path
@@ -245,7 +245,7 @@ Copyright (C) 1999-2005 Id Software, Inc.
         DirectoryInfo (Path.Combine (path, name))
 
 «k:module» «t:Pak» =
-    «k:let» «v:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<pack_t>») =
+    «k:let» «f:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<pack_t>») =
         «k:let» «k:mutable» «v:native» = NativePtr.read ptr
 
         {
@@ -256,20 +256,20 @@ Copyright (C) 1999-2005 Id Software, Inc.
         }
 
 «k:module» «t:ServerPakChecksum» =
-    «k:let» «v:createFrom_fs_serverPaks» («v:size»: «t:int») («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<int>») =
+    «k:let» «f:createFrom_fs_serverPaks» («v:size»: «t:int») («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<int>») =
         «k:match» NativePtr.isValid ptr «k:with»
         «:fsharp-ui-operator-face:|» «k:false» -> []
         «:fsharp-ui-operator-face:|» _ -> NativePtr.toList size ptr
 
 «k:module» «t:SearchPath» =
-    «k:let» «v:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
+    «k:let» «f:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
         «k:let» «k:mutable» «v:native» = NativePtr.read ptr
 
         {
             DirectoryInfo = Option.ofNativePtr DirectoryInfo.ofNativePtr native.directory
         }
 
-    «k:let» «v:convertFrom_fs_searchpaths» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
+    «k:let» «f:convertFrom_fs_searchpaths» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
         «k:let» «k:rec» «f:f» («v:searchPaths»: «t:SearchPath list») («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
             «k:match» NativePtr.isValid ptr «k:with»
             «:fsharp-ui-operator-face:|» «k:false» -> searchPaths

--- a/test/apps/FQuake3/NativeMappings.fs.faceup
+++ b/test/apps/FQuake3/NativeMappings.fs.faceup
@@ -220,7 +220,7 @@ Copyright (C) 1999-2005 Id Software, Inc.
         }
 
 «k:module» «t:Md3» =
-    «k:let» «f:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<md3Header_t>») =
+    «k:let» «v:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<md3Header_t>») =
         «k:let» «k:mutable» «v:native» = NativePtr.read ptr
 
         «k:let» «v:hash» = NativePtr.toNativeInt ptr
@@ -236,7 +236,7 @@ Copyright (C) 1999-2005 Id Software, Inc.
         md3
 
 «k:module» «t:DirectoryInfo» =
-    «k:let» «f:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<directory_t>») =
+    «k:let» «v:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<directory_t>») =
         «k:let» «k:mutable» «v:native» = NativePtr.read ptr
 
         «k:let» «v:path» = NativePtr.toStringAnsi &&native.path
@@ -245,7 +245,7 @@ Copyright (C) 1999-2005 Id Software, Inc.
         DirectoryInfo (Path.Combine (path, name))
 
 «k:module» «t:Pak» =
-    «k:let» «f:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<pack_t>») =
+    «k:let» «v:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<pack_t>») =
         «k:let» «k:mutable» «v:native» = NativePtr.read ptr
 
         {
@@ -256,20 +256,20 @@ Copyright (C) 1999-2005 Id Software, Inc.
         }
 
 «k:module» «t:ServerPakChecksum» =
-    «k:let» «f:createFrom_fs_serverPaks» («v:size»: «t:int») («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<int>») =
+    «k:let» «v:createFrom_fs_serverPaks» («v:size»: «t:int») («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<int>») =
         «k:match» NativePtr.isValid ptr «k:with»
         «:fsharp-ui-operator-face:|» «k:false» -> []
         «:fsharp-ui-operator-face:|» _ -> NativePtr.toList size ptr
 
 «k:module» «t:SearchPath» =
-    «k:let» «f:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
+    «k:let» «v:ofNativePtr» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
         «k:let» «k:mutable» «v:native» = NativePtr.read ptr
 
         {
             DirectoryInfo = Option.ofNativePtr DirectoryInfo.ofNativePtr native.directory
         }
 
-    «k:let» «f:convertFrom_fs_searchpaths» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
+    «k:let» «v:convertFrom_fs_searchpaths» («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
         «k:let» «k:rec» «f:f» («v:searchPaths»: «t:SearchPath list») («v:ptr»: «t:nativeptr»«:fsharp-ui-generic-face:<searchpath_t>») =
             «k:match» NativePtr.isValid ptr «k:with»
             «:fsharp-ui-operator-face:|» «k:false» -> searchPaths

--- a/test/apps/FSharp.Compatibility/Format.fs.faceup
+++ b/test/apps/FSharp.Compatibility/Format.fs.faceup
@@ -107,7 +107,7 @@
   «:fsharp-ui-operator-face:|» Nil
   «:fsharp-ui-operator-face:|» Cons «k:of» 'a queue_cell
 
-«k:and» «f:'a» «v:queue_cell» = {
+«k:and» 'a «v:queue_cell» = {
     «k:mutable» head : 'a;
     «k:mutable» tail : 'a queue_elem;
 }
@@ -184,13 +184,13 @@
 
  **************************************************************)»
 «m:/// »«x:Queues auxilliaries.
-»«k:let» «f:make_queue» () = { insert = Nil; body = Nil; }
+»«k:let» «v:make_queue» () = { insert = Nil; body = Nil; }
   
-«k:let» «f:clear_queue» «v:q» =
+«k:let» «v:clear_queue» «v:q» =
     q.insert <- Nil
     q.body <- Nil
   
-«k:let» «f:add_queue» «v:x» «v:q» =
+«k:let» «v:add_queue» «v:x» «v:q» =
     «k:let» «v:c» = Cons { head = x; tail = Nil; }
     «k:match» q «k:with»
     «:fsharp-ui-operator-face:|» { insert = Cons cell; body = _ } ->
@@ -215,11 +215,11 @@
   «:fsharp-ui-operator-face:|» { body = Nil; insert = _ } -> raise Empty_queue
   
 «x:(* Enter a token in the pretty-printer queue. *)»
-«k:let» «f:pp_enqueue» «v:state» (({ «v:length» = len; elem_size = _; token = _ } «k:as» token)) =
+«k:let» «v:pp_enqueue» «v:state» (({ «v:length» = len; elem_size = _; token = _ } «k:as» token)) =
     state.pp_right_total <- state.pp_right_total + len
     add_queue token state.pp_queue
   
-«k:let» «f:pp_clear_queue» «v:state» =
+«k:let» «v:pp_clear_queue» «v:state» =
     state.pp_left_total <- 1
     state.pp_right_total <- 1
     clear_queue state.pp_queue
@@ -248,11 +248,11 @@
   
 «x:(* Output functions for the formatter. *)»
 «k:let» «k:rec» «f:pp_output_string» «v:state» «v:s» = state.pp_out_string s 0 (String.length s)
-«k:and» «f:pp_output_newline» «v:state» = state.pp_out_newline ()
-«k:and» «f:pp_output_spaces» «v:state» «v:n» = state.pp_out_spaces n
+«k:and» «v:pp_output_newline» «v:state» = state.pp_out_newline ()
+«k:and» «v:pp_output_spaces» «v:state» «v:n» = state.pp_out_spaces n
   
 «x:(* To format a break, indenting a new line. *)»
-«k:let» «f:break_new_line» «v:state» «v:offset» «v:width» =
+«k:let» «v:break_new_line» «v:state» «v:offset» «v:width» =
   (pp_output_newline state;
    state.pp_is_new_line <- «k:true»;
    «k:let» «v:indent» = (state.pp_margin - width) + offset «k:in»
@@ -264,17 +264,17 @@
       pp_output_spaces state state.pp_current_indent))
   
 «x:(* To force a line break inside a block: no offset is added. *)»
-«k:let» «f:break_line» «v:state» «v:width» = break_new_line state 0 width
+«k:let» «v:break_line» «v:state» «v:width» = break_new_line state 0 width
   
 «x:(* To format a break that fits on the current line. *)»
-«k:let» «f:break_same_line» «v:state» «v:width» =
+«k:let» «v:break_same_line» «v:state» «v:width» =
   (state.pp_space_left <- state.pp_space_left - width;
    pp_output_spaces state width)
   
 «x:(* To indent no more than pp_max_indent, if one tries to open a block
    beyond pp_max_indent, then the block is rejected on the left
    by simulating a break. *)»
-«k:let» «f:pp_force_break_line» «v:state» =
+«k:let» «v:pp_force_break_line» «v:state» =
   «k:match» state.pp_format_stack «k:with»
   «:fsharp-ui-operator-face:|» Format_elem (bl_ty, width) :: _ ->
       «k:if» width > state.pp_space_left
@@ -287,7 +287,7 @@
   «:fsharp-ui-operator-face:|» [] -> pp_output_newline state
   
 «x:(* To skip a token, if the previous line has been broken. *)»
-«k:let» «f:pp_skip_token» «v:state» =
+«k:let» «v:pp_skip_token» «v:state» =
   «x:(* When calling pp_skip_token the queue cannot be empty. *)»
   «k:match» take_queue state.pp_queue «k:with»
   «:fsharp-ui-operator-face:|» { elem_size = size; length = len; token = _ } ->
@@ -300,7 +300,7 @@
 
  **************************************************************)»
 «x:(* To format a token. *)»
-«k:let» «f:format_pp_token» «v:state» «v:size» =
+«k:let» «v:format_pp_token» «v:state» «v:size» =
   «k:function»
   «:fsharp-ui-operator-face:|» Pp_text s ->
       (state.pp_space_left <- state.pp_space_left - size;
@@ -429,19 +429,19 @@
            advance_loop state)
         «k:else» ()
   
-«k:let» «f:advance_left» «v:state» = «k:try» advance_loop state «k:with» «:fsharp-ui-operator-face:|» Empty_queue -> ()
+«k:let» «v:advance_left» «v:state» = «k:try» advance_loop state «k:with» «:fsharp-ui-operator-face:|» Empty_queue -> ()
   
-«k:let» «f:enqueue_advance» «v:state» «v:tok» = (pp_enqueue state tok; advance_left state)
+«k:let» «v:enqueue_advance» «v:state» «v:tok» = (pp_enqueue state tok; advance_left state)
   
 «x:(* To enqueue a string : try to advance. *)»
-«k:let» «f:make_queue_elem» «v:size» «v:tok» «v:len» =
+«k:let» «v:make_queue_elem» «v:size» «v:tok» «v:len» =
   { elem_size = size; token = tok; length = len; }
   
-«k:let» «f:enqueue_string_as» «v:state» «v:size» «v:s» =
+«k:let» «v:enqueue_string_as» «v:state» «v:size» «v:s» =
   «k:let» «v:len» = int_of_size size
   «k:in» enqueue_advance state (make_queue_elem size (Pp_text s) len)
   
-«k:let» «f:enqueue_string» «v:state» «v:s» =
+«k:let» «v:enqueue_string» «v:state» «v:s» =
   «k:let» «v:len» = String.length s «k:in» enqueue_string_as state (size_of_int len) s
   
 «x:(* Routines for scan stack
@@ -454,13 +454,13 @@
 «x:(* Set size of blocks on scan stack:
    if ty = true then size of break is set else size of block is set;
    in each case pp_scan_stack is popped. *)»
-«k:let» «f:clear_scan_stack» «v:state» = state.pp_scan_stack <- scan_stack_bottom
+«k:let» «v:clear_scan_stack» «v:state» = state.pp_scan_stack <- scan_stack_bottom
   
 «x:(* Pattern matching on scan stack is exhaustive,
    since scan_stack is never empty.
    Pattern matching on token in scan stack is also exhaustive,
    since scan_push is used on breaks and opening of boxes. *)»
-«k:let» «f:set_size» «v:state» «v:ty» =
+«k:let» «v:set_size» «v:state» «v:ty» =
   «k:match» state.pp_scan_stack «k:with»
   «:fsharp-ui-operator-face:|» Scan_elem (left_tot,
       (({ elem_size = size; token = tok; length = _ } «k:as» queue_elem))) :: t
@@ -493,7 +493,7 @@
   
 «x:(* scan_stack is never empty. *)»
 «x:(* Push a token on scan stack. If b is true set_size is called. *)»
-«k:let» «f:scan_push» «v:state» «v:b» «v:tok» =
+«k:let» «v:scan_push» «v:state» «v:b» «v:tok» =
   (pp_enqueue state tok;
    «k:if» b «k:then» set_size state «k:true» «k:else» ();
    state.pp_scan_stack <-
@@ -502,7 +502,7 @@
 «x:(* To open a new block :
    the user may set the depth bound pp_max_boxes
    any text nested deeper is printed as the ellipsis string. *)»
-«k:let» «f:pp_open_box_gen» «v:state» «v:indent» «v:br_ty» =
+«k:let» «v:pp_open_box_gen» «v:state» «v:indent» «v:br_ty» =
   (state.pp_curr_depth <- state.pp_curr_depth + 1;
    «k:if» state.pp_curr_depth < state.pp_max_boxes
    «k:then»
@@ -516,10 +516,10 @@
      «k:else» ())
   
 «x:(* The box which is always opened. *)»
-«k:let» «f:pp_open_sys_box» «v:state» = pp_open_box_gen state 0 Pp_hovbox
+«k:let» «v:pp_open_sys_box» «v:state» = pp_open_box_gen state 0 Pp_hovbox
   
 «x:(* Close a block, setting sizes of its sub blocks. *)»
-«k:let» «f:pp_close_box» «v:state» () =
+«k:let» «v:pp_close_box» «v:state» () =
   «k:if» state.pp_curr_depth > 1
   «k:then»
     («k:if» state.pp_curr_depth < state.pp_max_boxes
@@ -533,7 +533,7 @@
   «k:else» ()
   
 «x:(* Open a tag, pushing it on the tag stack. *)»
-«k:let» «f:pp_open_tag» «v:state» «v:tag_name» =
+«k:let» «v:pp_open_tag» «v:state» «v:tag_name» =
   («k:if» state.pp_print_tags
    «k:then»
      (state.pp_tag_stack <- tag_name :: state.pp_tag_stack;
@@ -547,7 +547,7 @@
    «k:else» ())
   
 «x:(* Close a tag, popping it from the tag stack. *)»
-«k:let» «f:pp_close_tag» «v:state» () =
+«k:let» «v:pp_close_tag» «v:state» () =
   («k:if» state.pp_mark_tags
    «k:then»
      pp_enqueue state
@@ -562,18 +562,18 @@
    «k:else» ())
   
 «x:(* No more tag to close. *)»
-«k:let» «f:pp_set_print_tags» «v:state» «v:b» = state.pp_print_tags <- b
+«k:let» «v:pp_set_print_tags» «v:state» «v:b» = state.pp_print_tags <- b
   
-«k:let» «f:pp_set_mark_tags» «v:state» «v:b» = state.pp_mark_tags <- b
+«k:let» «v:pp_set_mark_tags» «v:state» «v:b» = state.pp_mark_tags <- b
   
-«k:let» «f:pp_get_print_tags» «v:state» () = state.pp_print_tags
+«k:let» «v:pp_get_print_tags» «v:state» () = state.pp_print_tags
   
-«k:let» «f:pp_get_mark_tags» «v:state» () = state.pp_mark_tags
+«k:let» «v:pp_get_mark_tags» «v:state» () = state.pp_mark_tags
   
-«k:let» «f:pp_set_tags» «v:state» «v:b» =
+«k:let» «v:pp_set_tags» «v:state» «v:b» =
   (pp_set_print_tags state b; pp_set_mark_tags state b)
   
-«k:let» «f:pp_get_formatter_tag_functions» «v:state» () =
+«k:let» «v:pp_get_formatter_tag_functions» «v:state» () =
   {
     mark_open_tag = state.pp_mark_open_tag;
     mark_close_tag = state.pp_mark_close_tag;
@@ -581,7 +581,7 @@
     print_close_tag = state.pp_print_close_tag;
   }
   
-«k:let» «f:pp_set_formatter_tag_functions» «v:state»
+«k:let» «v:pp_set_formatter_tag_functions» «v:state»
                                    {
                                      «v:mark_open_tag» = mot;
                                      mark_close_tag = mct;
@@ -594,7 +594,7 @@
    state.pp_print_close_tag <- pct)
   
 «x:(* Initialize pretty-printer. *)»
-«k:let» «f:pp_rinit» «v:state» =
+«k:let» «v:pp_rinit» «v:state» =
   (pp_clear_queue state;
    clear_scan_stack state;
    state.pp_format_stack <- [];
@@ -607,7 +607,7 @@
    pp_open_sys_box state)
   
 «x:(* Flushing pretty-printer queue. *)»
-«k:let» «f:pp_flush_queue» «v:state» «v:b» =
+«k:let» «v:pp_flush_queue» «v:state» «v:b» =
   («k:while» state.pp_curr_depth > 1 «k:do» pp_close_box state () «k:done»;
    state.pp_right_total <- pp_infinity;
    advance_left state;
@@ -620,52 +620,52 @@
 
  **************************************************************)»
 «x:(* To format a string. *)»
-«k:let» «f:pp_print_as_size» «v:state» «v:size» «v:s» =
+«k:let» «v:pp_print_as_size» «v:state» «v:size» «v:s» =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then» enqueue_string_as state size s
   «k:else» ()
   
-«k:let» «f:pp_print_as» «v:state» «v:isize» «v:s» = pp_print_as_size state (size_of_int isize) s
+«k:let» «v:pp_print_as» «v:state» «v:isize» «v:s» = pp_print_as_size state (size_of_int isize) s
   
-«k:let» «f:pp_print_string» «v:state» «v:s» = pp_print_as state (String.length s) s
+«k:let» «v:pp_print_string» «v:state» «v:s» = pp_print_as state (String.length s) s
   
 «x:(* To format an integer. *)»
-«k:let» «f:pp_print_int» «v:state» «v:i» = pp_print_string state (string_of_int i)
+«k:let» «v:pp_print_int» «v:state» «v:i» = pp_print_string state (string_of_int i)
   
 «x:(* To format a float. *)»
-«k:let» «f:pp_print_float» «v:state» «v:f» = pp_print_string state (string_of_float f)
+«k:let» «v:pp_print_float» «v:state» «v:f» = pp_print_string state (string_of_float f)
   
 «x:(* To format a boolean. *)»
-«k:let» «f:pp_print_bool» «v:state» «v:b» = pp_print_string state (string_of_bool b)
+«k:let» «v:pp_print_bool» «v:state» «v:b» = pp_print_string state (string_of_bool b)
   
 «x:(* To format a char. *)»
-«k:let» «f:pp_print_char» «v:state» («v:c» : «t:char») =
+«k:let» «v:pp_print_char» «v:state» («v:c» : «t:char») =
     pp_print_as state 1 (string c)
   
 «x:(* Opening boxes. *)»
 «k:let» «k:rec» «f:pp_open_hbox» «v:state» () = pp_open_box_gen state 0 Pp_hbox
-«k:and» «f:pp_open_vbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_vbox
-«k:and» «f:pp_open_hvbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_hvbox
-«k:and» «f:pp_open_hovbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_hovbox
-«k:and» «f:pp_open_box» «v:state» «v:indent» = pp_open_box_gen state indent Pp_box
+«k:and» «v:pp_open_vbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_vbox
+«k:and» «v:pp_open_hvbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_hvbox
+«k:and» «v:pp_open_hovbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_hovbox
+«k:and» «v:pp_open_box» «v:state» «v:indent» = pp_open_box_gen state indent Pp_box
   
 «x:(* Print a new line after printing all queued text
    (same for print_flush but without a newline). *)»
 «k:let» «k:rec» «f:pp_print_newline» «v:state» () =
     pp_flush_queue state «k:true»
     state.pp_out_flush ()
-«k:and» «f:pp_print_flush» «v:state» () =
+«k:and» «v:pp_print_flush» «v:state» () =
     pp_flush_queue state «k:false»
     state.pp_out_flush ()
   
 «x:(* To get a newline when one does not want to close the current block. *)»
-«k:let» «f:pp_force_newline» «v:state» () =
+«k:let» «v:pp_force_newline» «v:state» () =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then» enqueue_advance state (make_queue_elem (size_of_int 0) Pp_newline 0)
   «k:else» ()
   
 «x:(* To format something if the line has just been broken. *)»
-«k:let» «f:pp_print_if_newline» «v:state» () =
+«k:let» «v:pp_print_if_newline» «v:state» () =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then»
     enqueue_advance state (make_queue_elem (size_of_int 0) Pp_if_newline 0)
@@ -675,7 +675,7 @@
    If line is broken then offset is added to the indentation of the current
    block else (the value of) width blanks are printed.
    To do (?) : add a maximum width and offset value. *)»
-«k:let» «f:pp_print_break» «v:state» «v:width» «v:offset» =
+«k:let» «v:pp_print_break» «v:state» «v:width» «v:offset» =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then»
     («k:let» elem =
@@ -685,10 +685,10 @@
   «k:else» ()
   
 «k:let» «k:rec» «f:pp_print_space» «v:state» () = pp_print_break state 1 0
-«k:and» «f:pp_print_cut» «v:state» () = pp_print_break state 0 0
+«k:and» «v:pp_print_cut» «v:state» () = pp_print_break state 0 0
   
 «x:(* Tabulation boxes. *)»
-«k:let» «f:pp_open_tbox» «v:state» () =
+«k:let» «v:pp_open_tbox» «v:state» () =
   (state.pp_curr_depth <- state.pp_curr_depth + 1;
    «k:if» state.pp_curr_depth < state.pp_max_boxes
    «k:then»
@@ -698,7 +698,7 @@
    «k:else» ())
   
 «x:(* Close a tabulation block. *)»
-«k:let» «f:pp_close_tbox» «v:state» () =
+«k:let» «v:pp_close_tbox» «v:state» () =
   «k:if» state.pp_curr_depth > 1
   «k:then»
     «k:if» state.pp_curr_depth < state.pp_max_boxes
@@ -711,7 +711,7 @@
   «k:else» ()
   
 «x:(* Print a tabulation break. *)»
-«k:let» «f:pp_print_tbreak» «v:state» «v:width» «v:offset» =
+«k:let» «v:pp_print_tbreak» «v:state» «v:width» «v:offset» =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then»
     («k:let» elem =
@@ -720,9 +720,9 @@
      «k:in» scan_push state «k:true» elem)
   «k:else» ()
   
-«k:let» «f:pp_print_tab» «v:state» () = pp_print_tbreak state 0 0
+«k:let» «v:pp_print_tab» «v:state» () = pp_print_tbreak state 0 0
   
-«k:let» «f:pp_set_tab» «v:state» () =
+«k:let» «v:pp_set_tab» «v:state» () =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then»
     («k:let» elem = make_queue_elem (size_of_int 0) Pp_stab 0
@@ -735,21 +735,21 @@
 
  **************************************************************)»
 «x:(* Fit max_boxes. *)»
-«k:let» «f:pp_set_max_boxes» «v:state» «v:n» = «k:if» n > 1 «k:then» state.pp_max_boxes <- n «k:else» ()
+«k:let» «v:pp_set_max_boxes» «v:state» «v:n» = «k:if» n > 1 «k:then» state.pp_max_boxes <- n «k:else» ()
   
 «x:(* To know the current maximum number of boxes allowed. *)»
-«k:let» «f:pp_get_max_boxes» «v:state» () = state.pp_max_boxes
+«k:let» «v:pp_get_max_boxes» «v:state» () = state.pp_max_boxes
   
-«k:let» «f:pp_over_max_boxes» «v:state» () = state.pp_curr_depth = state.pp_max_boxes
+«k:let» «v:pp_over_max_boxes» «v:state» () = state.pp_curr_depth = state.pp_max_boxes
   
 «x:(* Ellipsis. *)»
 «k:let» «k:rec» «f:pp_set_ellipsis_text» «v:state» «v:s» = state.pp_ellipsis <- s
-«k:and» «f:pp_get_ellipsis_text» «v:state» () = state.pp_ellipsis
+«k:and» «v:pp_get_ellipsis_text» «v:state» () = state.pp_ellipsis
   
 «x:(* To set the margin of pretty-printer. *)»
-«k:let» «f:pp_limit» «v:n» = «k:if» n < pp_infinity «k:then» n «k:else» pred pp_infinity
+«k:let» «v:pp_limit» «v:n» = «k:if» n < pp_infinity «k:then» n «k:else» pred pp_infinity
   
-«k:let» «f:pp_set_min_space_left» «v:state» «v:n» =
+«k:let» «v:pp_set_min_space_left» «v:state» «v:n» =
   «k:if» n >= 1
   «k:then»
     («k:let» n = pp_limit n
@@ -762,12 +762,12 @@
 «x:(* Initially, we have :
   pp_max_indent = pp_margin - pp_min_space_left, and
   pp_space_left = pp_margin. *)»
-«k:let» «f:pp_set_max_indent» «v:state» «v:n» =
+«k:let» «v:pp_set_max_indent» «v:state» «v:n» =
   pp_set_min_space_left state (state.pp_margin - n)
   
-«k:let» «f:pp_get_max_indent» «v:state» () = state.pp_max_indent
+«k:let» «v:pp_get_max_indent» «v:state» () = state.pp_max_indent
   
-«k:let» «f:pp_set_margin» «v:state» «v:n» =
+«k:let» «v:pp_set_margin» «v:state» «v:n» =
   «k:if» n >= 1
   «k:then»
     («k:let» n = pp_limit n
@@ -788,7 +788,7 @@
         «k:in» «x:(* Rebuild invariants. *)» pp_set_max_indent state new_max_indent))
   «k:else» ()
   
-«k:let» «f:pp_get_margin» «v:state» () = state.pp_margin
+«k:let» «v:pp_get_margin» «v:state» () = state.pp_margin
   
 «k:type» formatter_out_functions = {
     out_string : «t:string» -> int -> int -> unit;
@@ -797,7 +797,7 @@
     out_spaces : «t:int» -> unit
   }
 
-«k:let» «f:pp_set_formatter_out_functions» «v:state»
+«k:let» «v:pp_set_formatter_out_functions» «v:state»
                                    {
                                      «v:out_string» = f;
                                      out_flush = g;
@@ -809,7 +809,7 @@
     state.pp_out_newline <- h
     state.pp_out_spaces <- i
   
-«k:let» «f:pp_get_formatter_out_functions» «v:state» () =
+«k:let» «v:pp_get_formatter_out_functions» «v:state» () =
   {
     out_string = state.pp_out_string;
     out_flush = state.pp_out_flush;
@@ -817,26 +817,26 @@
     out_spaces = state.pp_out_spaces;
   }
   
-«k:let» «f:pp_set_formatter_output_functions» «v:state» «v:f» «v:g» =
+«k:let» «v:pp_set_formatter_output_functions» «v:state» «v:f» «v:g» =
   (state.pp_out_string <- f; state.pp_out_flush <- g)
   
-«k:let» «f:pp_get_formatter_output_functions» «v:state» () =
+«k:let» «v:pp_get_formatter_output_functions» «v:state» () =
     state.pp_out_string, state.pp_out_flush
   
 «m://»«x:let pp_set_all_formatter_output_functions state ~out:f ~flush:g ~newline:h ~spaces:i =
-»«k:let» «f:pp_set_all_formatter_output_functions» «v:state» «v:f» «v:g» «v:h» «v:i» =
+»«k:let» «v:pp_set_all_formatter_output_functions» «v:state» «v:f» «v:g» «v:h» «v:i» =
     pp_set_formatter_output_functions state f g
     state.pp_out_newline <- h
     state.pp_out_spaces <- i
   
-«k:let» «f:pp_get_all_formatter_output_functions» «v:state» () =
+«k:let» «v:pp_get_all_formatter_output_functions» «v:state» () =
     state.pp_out_string,
     state.pp_out_flush,
     state.pp_out_newline,
     state.pp_out_spaces
   
 «x:(* Default function to output new lines. *)»
-«k:let» «f:display_newline» «v:state» () = state.pp_out_string «s:"\n"» 0 1
+«k:let» «v:display_newline» «v:state» () = state.pp_out_string «s:"\n"» 0 1
   
 «x:(* Default function to output spaces. *)»
 «k:let» «v:blank_line» = String.make 80 «s:' '»
@@ -852,7 +852,7 @@
 »«k:let» «k:private» «v:output» «v:oc» («v:buf» : «t:string») («v:pos» : «t:int») («v:len» : «t:int») =
     output_string oc (buf.Substring (pos, len))
 
-«k:let» «f:pp_set_formatter_out_channel» «v:state» «v:os» =
+«k:let» «v:pp_set_formatter_out_channel» «v:state» «v:os» =
    state.pp_out_string <- output os
    state.pp_out_flush <- («k:fun» () -> flush os)
    state.pp_out_newline <- display_newline state
@@ -863,15 +863,15 @@
   Creation of specific formatters
 
  **************************************************************)»
-«k:let» «f:default_pp_mark_open_tag» «v:s» = «s:"<"» ^ (s ^ «s:">"»)
+«k:let» «v:default_pp_mark_open_tag» «v:s» = «s:"<"» ^ (s ^ «s:">"»)
   
-«k:let» «f:default_pp_mark_close_tag» «v:s» = «s:"</"» ^ (s ^ «s:">"»)
+«k:let» «v:default_pp_mark_close_tag» «v:s» = «s:"</"» ^ (s ^ «s:">"»)
   
 «k:let» «v:default_pp_print_open_tag» = ignore
   
 «k:let» «v:default_pp_print_close_tag» = ignore
   
-«k:let» «f:pp_make_formatter» «v:f» «v:g» «v:h» «v:i» =
+«k:let» «v:pp_make_formatter» «v:f» «v:g» «v:h» «v:i» =
   «x:(* The initial state of the formatter contains a dummy box. *)»
   «k:let» «v:pp_q» = make_queue () «k:in»
   «k:let» «v:sys_tok» =
@@ -911,17 +911,17 @@
        })
   
 «x:(* Make a formatter with default functions to output spaces and new lines. *)»
-«k:let» «f:make_formatter» «v:output» «v:flush» =
+«k:let» «v:make_formatter» «v:output» «v:flush» =
   «k:let» «v:ppf» = pp_make_formatter output flush ignore ignore
   «k:in»
     (ppf.pp_out_newline <- display_newline ppf;
      ppf.pp_out_spaces <- display_blanks ppf;
      ppf)
   
-«k:let» «f:formatter_of_out_channel» «v:oc» =
+«k:let» «v:formatter_of_out_channel» «v:oc» =
   make_formatter (output oc) («k:fun» () -> flush oc)
   
-«k:let» «f:formatter_of_buffer» «v:b» = make_formatter (Buffer.add_substring b) ignore
+«k:let» «v:formatter_of_buffer» «v:b» = make_formatter (Buffer.add_substring b) ignore
   
 «k:let» «v:stdbuf» = Buffer.create 512
   
@@ -930,7 +930,7 @@
 «k:and» «v:err_formatter» = formatter_of_out_channel Pervasives.stderr
 «k:and» «v:str_formatter» = formatter_of_buffer stdbuf
   
-«k:let» «f:flush_str_formatter» () =
+«k:let» «v:flush_str_formatter» () =
   (pp_flush_queue str_formatter «k:false»;
    «k:let» «v:s» = Buffer.contents stdbuf «k:in» (Buffer.reset stdbuf; s))
   
@@ -974,7 +974,7 @@
 «k:and» «v:over_max_boxes» = pp_over_max_boxes std_formatter
 «k:and» «v:set_ellipsis_text» = pp_set_ellipsis_text std_formatter
 «k:and» «v:get_ellipsis_text» = pp_get_ellipsis_text std_formatter
-«k:and» «f:set_formatter_out_channel» («v:channel» : «t:out_channel») =
+«k:and» «v:set_formatter_out_channel» («v:channel» : «t:out_channel») =
     pp_set_formatter_out_channel std_formatter channel
 «k:and» «v:set_formatter_out_functions» =
   pp_set_formatter_out_functions std_formatter
@@ -1009,7 +1009,7 @@
   
 «x:(* Error messages when processing formats. *)»
 «x:(* Trailer: giving up at character number ... *)»
-«k:let» «f:giving_up» «v:mess» «v:fmt» «v:i» =
+«k:let» «v:giving_up» «v:mess» «v:fmt» «v:i» =
     sprintf «s:"Format.fprintf: %s ``%s'', giving up at character number %d%s"»
         mess (Sformat.to_string fmt) i
         («k:if» i < Sformat.length fmt
@@ -1017,36 +1017,36 @@
          «k:else» sprintf «s:"%c"» «s:'.'»)
   
 «x:(* When an invalid format deserves a special error explanation. *)»
-«k:let» «f:format_invalid_arg» «v:mess» «v:fmt» «v:i» = invalid_arg (giving_up mess fmt i)
+«k:let» «v:format_invalid_arg» «v:mess» «v:fmt» «v:i» = invalid_arg (giving_up mess fmt i)
   
 «x:(* Standard invalid format. *)»
-«k:let» «f:invalid_format» «v:fmt» «v:i» = format_invalid_arg «s:"bad format"» fmt i
+«k:let» «v:invalid_format» «v:fmt» «v:i» = format_invalid_arg «s:"bad format"» fmt i
   
 «x:(* Cannot find a valid integer into that format. *)»
-«k:let» «f:invalid_integer» «v:fmt» «v:i» =
+«k:let» «v:invalid_integer» «v:fmt» «v:i» =
   invalid_arg (giving_up «s:"bad integer specification"» fmt i)
   
 «x:(* Finding an integer size out of a sub-string of the format. *)»
-«k:let» «f:format_int_of_string» «v:fmt» «v:i» «v:s» =
+«k:let» «v:format_int_of_string» «v:fmt» «v:i» «v:s» =
   «k:let» «v:sz» = «k:try» int_of_string s «k:with» «:fsharp-ui-operator-face:|» Failure _ -> invalid_integer fmt i
   «k:in» size_of_int sz
   
 «x:(* Getting strings out of buffers. *)»
-«k:let» «f:get_buffer_out» «v:b» = «k:let» s = Buffer.contents b «k:in» (Buffer.reset b; s)
+«k:let» «v:get_buffer_out» «v:b» = «k:let» s = Buffer.contents b «k:in» (Buffer.reset b; s)
   
 «x:(* [ppf] is supposed to be a pretty-printer that outputs to buffer [b]:
    to extract the contents of [ppf] as a string we flush [ppf] and get the
    string out of [b]. *)»
-«k:let» «f:string_out» «v:b» «v:ppf» = (pp_flush_queue ppf «k:false»; get_buffer_out b)
+«k:let» «v:string_out» «v:b» «v:ppf» = (pp_flush_queue ppf «k:false»; get_buffer_out b)
   
 «x:(* Applies [printer] to a formatter that outputs on a fresh buffer,
    then returns the resulting material. *)»
-«k:let» «f:exstring» «v:printer» «v:arg» =
+«k:let» «v:exstring» «v:printer» «v:arg» =
   «k:let» «v:b» = Buffer.create 512 «k:in»
   «k:let» «v:ppf» = formatter_of_buffer b «k:in» (printer ppf arg; string_out b ppf)
   
 «x:(* To turn out a character accumulator into the proper string result. *)»
-«k:let» «f:implode_rev» «v:s0» = «k:function»
+«k:let» «v:implode_rev» «v:s0» = «k:function»
   «:fsharp-ui-operator-face:|» [] -> s0
   «:fsharp-ui-operator-face:|» l -> String.concat «s:""» (List.rev (s0 :: l))
   
@@ -1060,10 +1060,10 @@
    according to the format string.
    Regular [fprintf]-like functions of this module are obtained via partial
    applications of [mkprintf]. *)»
-«k:let» «f:mkprintf» «v:to_s» «v:get_out» =
+«k:let» «v:mkprintf» «v:to_s» «v:get_out» =
   «k:let» «k:rec» «f:kprintf» «v:k» «v:fmt» =
     «k:let» «v:len» = Sformat.length fmt «k:in»
-    «k:let» «f:kpr» «v:fmt» «v:v» =
+    «k:let» «v:kpr» «v:fmt» «v:v» =
       «k:let» «v:ppf» = get_out fmt «k:in»
       «k:let» «v:print_as» = ref None «k:in»
       «k:let» «k:rec» «f:pp_print_as_char» «v:c» =
@@ -1071,7 +1071,7 @@
         «:fsharp-ui-operator-face:|» None -> pp_print_char ppf c
         «:fsharp-ui-operator-face:|» Some size ->
             (pp_print_as_size ppf size (String.make 1 c); print_as := None)
-      «k:and» «f:pp_print_as_string» «v:s» =
+      «k:and» «v:pp_print_as_string» «v:s» =
         «k:match» !print_as «k:with»
         «:fsharp-ui-operator-face:|» None -> pp_print_string ppf s
         «:fsharp-ui-operator-face:|» Some size -> (pp_print_as_size ppf size s; print_as := None) «k:in»
@@ -1101,29 +1101,29 @@
                     «:fsharp-ui-operator-face:|» «s:'\n'» -> (pp_force_newline ppf (); doprn n (succ i))
                     «:fsharp-ui-operator-face:|» «s:';'» -> do_pp_break ppf n (succ i)
                     «:fsharp-ui-operator-face:|» «s:'<'» ->
-                        «k:let» «f:got_size» «v:size» «v:n» «v:i» =
+                        «k:let» «v:got_size» «v:size» «v:n» «v:i» =
                           (print_as := Some size; doprn n (skip_gt i))
                         «k:in» get_int n (succ i) got_size
                     «:fsharp-ui-operator-face:|» («s:'@'» «:fsharp-ui-operator-face:|» «s:'%'» «k:as» c) ->
                         (pp_print_as_char c; doprn n (succ i))
                     «:fsharp-ui-operator-face:|» _ -> invalid_format fmt i)
            «:fsharp-ui-operator-face:|» c -> (pp_print_as_char c; doprn n (succ i)))
-      «k:and» «f:cont_s» «v:n» «v:s» «v:i» = (pp_print_as_string s; doprn n i)
-      «k:and» «f:cont_a» «v:n» «v:printer» «v:arg» «v:i» =
+      «k:and» «v:cont_s» «v:n» «v:s» «v:i» = (pp_print_as_string s; doprn n i)
+      «k:and» «v:cont_a» «v:n» «v:printer» «v:arg» «v:i» =
         («k:if» to_s
          «k:then»
            pp_print_as_string
              ((Obj.magic printer : «t:unit» -> _ -> string) () arg)
          «k:else» printer ppf arg;
          doprn n i)
-      «k:and» «f:cont_t» «v:n» «v:printer» «v:i» =
+      «k:and» «v:cont_t» «v:n» «v:printer» «v:i» =
         («k:if» to_s
          «k:then» pp_print_as_string ((Obj.magic printer : «t:unit» -> string) ())
          «k:else» printer ppf;
          doprn n i)
-      «k:and» «f:cont_f» «v:n» «v:i» = (pp_print_flush ppf (); doprn n i)
-      «k:and» «f:cont_m» «v:n» «v:sfmt» «v:i» = kprintf (Obj.magic («k:fun» «v:_» -> doprn n i)) sfmt
-      «k:and» «f:get_int» «v:n» «v:i» «v:c» =
+      «k:and» «v:cont_f» «v:n» «v:i» = (pp_print_flush ppf (); doprn n i)
+      «k:and» «v:cont_m» «v:n» «v:sfmt» «v:i» = kprintf (Obj.magic («k:fun» «v:_» -> doprn n i)) sfmt
+      «k:and» «v:get_int» «v:n» «v:i» «v:c» =
         «k:if» i >= len
         «k:then» invalid_integer fmt i
         «k:else»
@@ -1131,10 +1131,10 @@
            «:fsharp-ui-operator-face:|» «s:' '» -> get_int n (succ i) c
            «:fsharp-ui-operator-face:|» «s:'%'» ->
                «k:let» «k:rec» «f:cont_s» «v:n» «v:s» «v:i» = c (format_int_of_string fmt i s) n i
-               «k:and» «f:cont_a» «v:_n» «v:_printer» «v:_arg» «v:i» = invalid_integer fmt i
-               «k:and» «f:cont_t» «v:_n» «v:_printer» «v:i» = invalid_integer fmt i
-               «k:and» «f:cont_f» «v:_n» «v:i» = invalid_integer fmt i
-               «k:and» «f:cont_m» «v:_n» «v:_sfmt» «v:i» = invalid_integer fmt i
+               «k:and» «v:cont_a» «v:_n» «v:_printer» «v:_arg» «v:i» = invalid_integer fmt i
+               «k:and» «v:cont_t» «v:_n» «v:_printer» «v:i» = invalid_integer fmt i
+               «k:and» «v:cont_f» «v:_n» «v:i» = invalid_integer fmt i
+               «k:and» «v:cont_m» «v:_n» «v:_sfmt» «v:i» = invalid_integer fmt i
                «k:in»
                  Tformat.scan_format fmt v n i cont_s cont_a cont_t cont_f
                    cont_m
@@ -1158,7 +1158,7 @@
                              «k:in» format_int_of_string fmt j s)
                         «k:in» c size n j)
                «k:in» get i)
-      «k:and» «f:skip_gt» «v:i» =
+      «k:and» «v:skip_gt» «v:i» =
         «k:if» i >= len
         «k:then» invalid_format fmt i
         «k:else»
@@ -1166,7 +1166,7 @@
            «:fsharp-ui-operator-face:|» «s:' '» -> skip_gt (succ i)
            «:fsharp-ui-operator-face:|» «s:'>'» -> succ i
            «:fsharp-ui-operator-face:|» _ -> invalid_format fmt i)
-      «k:and» «f:get_box_kind» «v:i» =
+      «k:and» «v:get_box_kind» «v:i» =
         «k:if» i >= len
         «k:then» (Pp_box, i)
         «k:else»
@@ -1195,7 +1195,7 @@
            «:fsharp-ui-operator-face:|» «s:'b'» -> (Pp_box, (succ i))
            «:fsharp-ui-operator-face:|» «s:'v'» -> (Pp_vbox, (succ i))
            «:fsharp-ui-operator-face:|» _ -> (Pp_box, i))
-      «k:and» «f:get_tag_name» «v:n» «v:i» «v:c» =
+      «k:and» «v:get_tag_name» «v:n» «v:i» «v:c» =
         «k:let» «k:rec» «f:get» «v:accu» «v:n» «v:i» «v:j» =
           «k:if» j >= len
           «k:then»
@@ -1213,28 +1213,28 @@
              «:fsharp-ui-operator-face:|» «s:'%'» ->
                  «k:let» «v:s0» = Sformat.sub fmt (Sformat.index_of_int i) (j - i) «k:in»
                  «k:let» «k:rec» «f:cont_s» «v:n» «v:s» «v:i» = get (s :: s0 :: accu) n i i
-                 «k:and» «f:cont_a» «v:n» «v:printer» «v:arg» «v:i» =
+                 «k:and» «v:cont_a» «v:n» «v:printer» «v:arg» «v:i» =
                    «k:let» «v:s» =
                      «k:if» to_s
                      «k:then» (Obj.magic printer : «t:unit» -> _ -> string) () arg
                      «k:else» exstring printer arg
                    «k:in» get (s :: s0 :: accu) n i i
-                 «k:and» «f:cont_t» «v:n» «v:printer» «v:i» =
+                 «k:and» «v:cont_t» «v:n» «v:printer» «v:i» =
                    «k:let» «v:s» =
                      «k:if» to_s
                      «k:then» (Obj.magic printer : «t:unit» -> string) ()
                      «k:else» exstring («k:fun» «v:ppf» () -> printer ppf) ()
                    «k:in» get (s :: s0 :: accu) n i i
-                 «k:and» «f:cont_f» «v:_n» «v:i» =
+                 «k:and» «v:cont_f» «v:_n» «v:i» =
                    format_invalid_arg «s:"bad tag name specification"» fmt i
-                 «k:and» «f:cont_m» «v:_n» «v:_sfmt» «v:i» =
+                 «k:and» «v:cont_m» «v:_n» «v:_sfmt» «v:i» =
                    format_invalid_arg «s:"bad tag name specification"» fmt i
                  «k:in»
                    Tformat.scan_format fmt v n j cont_s cont_a cont_t cont_f
                      cont_m
              «:fsharp-ui-operator-face:|» _ -> get accu n i (succ j))
         «k:in» get [] n i i
-      «k:and» «f:do_pp_break» «v:ppf» «v:n» «v:i» =
+      «k:and» «v:do_pp_break» «v:ppf» «v:n» «v:i» =
         «k:if» i >= len
         «k:then» (pp_print_space ppf (); doprn n i)
         «k:else»
@@ -1242,31 +1242,31 @@
            «:fsharp-ui-operator-face:|» «s:'<'» ->
                «k:let» «k:rec» «f:got_nspaces» «v:nspaces» «v:n» «v:i» =
                  get_int n i (got_offset nspaces)
-               «k:and» «f:got_offset» «v:nspaces» «v:offset» «v:n» «v:i» =
+               «k:and» «v:got_offset» «v:nspaces» «v:offset» «v:n» «v:i» =
                  (pp_print_break ppf (int_of_size nspaces)
                     (int_of_size offset);
                   doprn n (skip_gt i))
                «k:in» get_int n (succ i) got_nspaces
            «:fsharp-ui-operator-face:|» _c -> (pp_print_space ppf (); doprn n i))
-      «k:and» «f:do_pp_open_box» «v:ppf» «v:n» «v:i» =
+      «k:and» «v:do_pp_open_box» «v:ppf» «v:n» «v:i» =
         «k:if» i >= len
         «k:then» (pp_open_box_gen ppf 0 Pp_box; doprn n i)
         «k:else»
           («k:match» Sformat.get fmt i «k:with»
            «:fsharp-ui-operator-face:|» «s:'<'» ->
                «k:let» («v:kind», «v:i») = get_box_kind (succ i) «k:in»
-               «k:let» «f:got_size» «v:size» «v:n» «v:i» =
+               «k:let» «v:got_size» «v:size» «v:n» «v:i» =
                  (pp_open_box_gen ppf (int_of_size size) kind;
                   doprn n (skip_gt i))
                «k:in» get_int n i got_size
            «:fsharp-ui-operator-face:|» _c -> (pp_open_box_gen ppf 0 Pp_box; doprn n i))
-      «k:and» «f:do_pp_open_tag» «v:ppf» «v:n» «v:i» =
+      «k:and» «v:do_pp_open_tag» «v:ppf» «v:n» «v:i» =
         «k:if» i >= len
         «k:then» (pp_open_tag ppf «s:""»; doprn n i)
         «k:else»
           («k:match» Sformat.get fmt i «k:with»
            «:fsharp-ui-operator-face:|» «s:'<'» ->
-               «k:let» «f:got_name» «v:tag_name» «v:n» «v:i» =
+               «k:let» «v:got_name» «v:tag_name» «v:n» «v:i» =
                  (pp_open_tag ppf tag_name; doprn n (skip_gt i))
                «k:in» get_tag_name n (succ i) got_name
            «:fsharp-ui-operator-face:|» _c -> (pp_open_tag ppf «s:""»; doprn n i))
@@ -1279,34 +1279,34 @@
   Defining [fprintf] and various flavors of [fprintf].
 
  **************************************************************)»
-«k:let» «f:kfprintf» «v:k» «v:ppf» = mkprintf «k:false» («k:fun» «v:_» -> ppf) k
+«k:let» «v:kfprintf» «v:k» «v:ppf» = mkprintf «k:false» («k:fun» «v:_» -> ppf) k
   
-«k:let» «f:ikfprintf» «v:k» «v:ppf» = Tformat.kapr («k:fun» «v:_» «v:_» -> Obj.magic (k ppf))
+«k:let» «v:ikfprintf» «v:k» «v:ppf» = Tformat.kapr («k:fun» «v:_» «v:_» -> Obj.magic (k ppf))
   
-«k:let» «f:fprintf» «v:ppf» = kfprintf ignore ppf
+«k:let» «v:fprintf» «v:ppf» = kfprintf ignore ppf
   
-«k:let» «f:ifprintf» «v:ppf» = ikfprintf ignore ppf
+«k:let» «v:ifprintf» «v:ppf» = ikfprintf ignore ppf
   
-«k:let» «f:printf» «v:fmt» = fprintf std_formatter fmt
+«k:let» «v:printf» «v:fmt» = fprintf std_formatter fmt
   
-«k:let» «f:eprintf» «v:fmt» = fprintf err_formatter fmt
+«k:let» «v:eprintf» «v:fmt» = fprintf err_formatter fmt
   
-«k:let» «f:ksprintf» «v:k» =
+«k:let» «v:ksprintf» «v:k» =
   «k:let» «v:b» = Buffer.create 512 «k:in»
-  «k:let» «f:k» «v:ppf» = k (string_out b ppf)
+  «k:let» «v:k» «v:ppf» = k (string_out b ppf)
   «k:in» mkprintf «k:true» («k:fun» «v:_» -> formatter_of_buffer b) k
   
-«k:let» «f:sprintf» «v:fmt» = ksprintf («k:fun» «v:s» -> s) fmt
+«k:let» «v:sprintf» «v:fmt» = ksprintf («k:fun» «v:s» -> s) fmt
   
 «x:(**************************************************************
 
   Deprecated stuff.
 
  **************************************************************)»
-«k:let» «f:kbprintf» «v:k» «v:b» = mkprintf «k:false» («k:fun» «v:_» -> formatter_of_buffer b) k
+«k:let» «v:kbprintf» «v:k» «v:b» = mkprintf «k:false» («k:fun» «v:_» -> formatter_of_buffer b) k
   
 «x:(* Deprecated error prone function bprintf. *)»
-«k:let» «f:bprintf» «v:b» = «k:let» «f:k» ppf = pp_flush_queue ppf «k:false» «k:in» kbprintf k b
+«k:let» «v:bprintf» «v:b» = «k:let» k ppf = pp_flush_queue ppf «k:false» «k:in» kbprintf k b
   
 «x:(* Deprecated alias for ksprintf. *)»
 «k:let» «v:kprintf» = ksprintf

--- a/test/apps/FSharp.Compatibility/Format.fs.faceup
+++ b/test/apps/FSharp.Compatibility/Format.fs.faceup
@@ -23,12 +23,12 @@
 
  **************************************************************)»
 «m:// »«x:TODO : Recreate 'size' as a measure type on int
-»«k:type» size = int
+»«k:type» «t:size» = int
 «k:let» «k:inline» «f:size_of_int» («v:n» : «t:int») : «t:size» = n
 «k:let» «k:inline» «f:int_of_size» («v:s» : «t:size») : «t:int» = s
   
 «x:(* Tokens are one of the following : *)»
-«k:type» pp_token =
+«k:type» «t:pp_token» =
     «x:(* normal text *)»
     «:fsharp-ui-operator-face:|» Pp_text «k:of» string
     «x:(* complete break *)»
@@ -83,7 +83,7 @@
    elements are tuples (size, token, length), where
    size is set when the size of the block is known
    len is the declared length of the token. *)»
-«k:type» pp_queue_elem = {
+«k:type» «t:pp_queue_elem» = {
     «k:mutable» elem_size : «t:size»;
     token : «t:pp_token»;
     length : «t:int»;
@@ -92,18 +92,18 @@
 «x:(* Scan stack:
    each element is (left_total, queue element) where left_total
    is the value of pp_left_total when the element has been enqueued. *)»
-«k:type» pp_scan_elem =
+«k:type» «t:pp_scan_elem» =
     «:fsharp-ui-operator-face:|» Scan_elem «k:of» int * pp_queue_elem
 
 «x:(* Formatting stack:
    used to break the lines while printing tokens.
    The formatting stack contains the description of
    the currently active blocks. *)»
-«k:type» pp_format_elem =
+«k:type» «t:pp_format_elem» =
     «:fsharp-ui-operator-face:|» Format_elem «k:of» block_type * int
 
 «x:(* General purpose queues, used in the formatter. *)»
-«k:type» 'a queue_elem =
+«k:type» «t:'a» «v:queue_elem» =
   «:fsharp-ui-operator-face:|» Nil
   «:fsharp-ui-operator-face:|» Cons «k:of» 'a queue_cell
 
@@ -112,13 +112,13 @@
     «k:mutable» tail : 'a queue_elem;
 }
 
-«k:type» 'a queue = {
+«k:type» «t:'a» «v:queue» = {
     «k:mutable» insert : 'a queue_elem;
     «k:mutable» body : 'a queue_elem;
 }
 
 «x:(* The formatter specific tag handling functions. *)»
-«k:type» formatter_tag_functions = {
+«k:type» «t:formatter_tag_functions» = {
     mark_open_tag : «t:tag» -> string;
     mark_close_tag : «t:tag» -> string;
     print_open_tag : «t:tag» -> unit;
@@ -126,7 +126,7 @@
   }
 
 «x:(* A formatter with all its machinery. *)»
-«k:type» formatter = {
+«k:type» «t:formatter» = {
     «k:mutable» pp_scan_stack : «t:pp_scan_elem list»;
     «k:mutable» pp_format_stack : «t:pp_format_elem list»;
     «k:mutable» pp_tbox_stack : «t:tblock list»;
@@ -790,7 +790,7 @@
   
 «k:let» «f:pp_get_margin» «v:state» () = state.pp_margin
   
-«k:type» formatter_out_functions = {
+«k:type» «t:formatter_out_functions» = {
     out_string : «t:string» -> int -> int -> unit;
     out_flush : «t:unit» -> unit;
     out_newline : «t:unit» -> unit;

--- a/test/apps/FSharp.Compatibility/Format.fs.faceup
+++ b/test/apps/FSharp.Compatibility/Format.fs.faceup
@@ -107,7 +107,7 @@
   «:fsharp-ui-operator-face:|» Nil
   «:fsharp-ui-operator-face:|» Cons «k:of» 'a queue_cell
 
-«k:and» 'a «v:queue_cell» = {
+«k:and» «f:'a» «v:queue_cell» = {
     «k:mutable» head : 'a;
     «k:mutable» tail : 'a queue_elem;
 }
@@ -184,13 +184,13 @@
 
  **************************************************************)»
 «m:/// »«x:Queues auxilliaries.
-»«k:let» «v:make_queue» () = { insert = Nil; body = Nil; }
+»«k:let» «f:make_queue» () = { insert = Nil; body = Nil; }
   
-«k:let» «v:clear_queue» «v:q» =
+«k:let» «f:clear_queue» «v:q» =
     q.insert <- Nil
     q.body <- Nil
   
-«k:let» «v:add_queue» «v:x» «v:q» =
+«k:let» «f:add_queue» «v:x» «v:q» =
     «k:let» «v:c» = Cons { head = x; tail = Nil; }
     «k:match» q «k:with»
     «:fsharp-ui-operator-face:|» { insert = Cons cell; body = _ } ->
@@ -215,11 +215,11 @@
   «:fsharp-ui-operator-face:|» { body = Nil; insert = _ } -> raise Empty_queue
   
 «x:(* Enter a token in the pretty-printer queue. *)»
-«k:let» «v:pp_enqueue» «v:state» (({ «v:length» = len; elem_size = _; token = _ } «k:as» token)) =
+«k:let» «f:pp_enqueue» «v:state» (({ «v:length» = len; elem_size = _; token = _ } «k:as» token)) =
     state.pp_right_total <- state.pp_right_total + len
     add_queue token state.pp_queue
   
-«k:let» «v:pp_clear_queue» «v:state» =
+«k:let» «f:pp_clear_queue» «v:state» =
     state.pp_left_total <- 1
     state.pp_right_total <- 1
     clear_queue state.pp_queue
@@ -248,11 +248,11 @@
   
 «x:(* Output functions for the formatter. *)»
 «k:let» «k:rec» «f:pp_output_string» «v:state» «v:s» = state.pp_out_string s 0 (String.length s)
-«k:and» «v:pp_output_newline» «v:state» = state.pp_out_newline ()
-«k:and» «v:pp_output_spaces» «v:state» «v:n» = state.pp_out_spaces n
+«k:and» «f:pp_output_newline» «v:state» = state.pp_out_newline ()
+«k:and» «f:pp_output_spaces» «v:state» «v:n» = state.pp_out_spaces n
   
 «x:(* To format a break, indenting a new line. *)»
-«k:let» «v:break_new_line» «v:state» «v:offset» «v:width» =
+«k:let» «f:break_new_line» «v:state» «v:offset» «v:width» =
   (pp_output_newline state;
    state.pp_is_new_line <- «k:true»;
    «k:let» «v:indent» = (state.pp_margin - width) + offset «k:in»
@@ -264,17 +264,17 @@
       pp_output_spaces state state.pp_current_indent))
   
 «x:(* To force a line break inside a block: no offset is added. *)»
-«k:let» «v:break_line» «v:state» «v:width» = break_new_line state 0 width
+«k:let» «f:break_line» «v:state» «v:width» = break_new_line state 0 width
   
 «x:(* To format a break that fits on the current line. *)»
-«k:let» «v:break_same_line» «v:state» «v:width» =
+«k:let» «f:break_same_line» «v:state» «v:width» =
   (state.pp_space_left <- state.pp_space_left - width;
    pp_output_spaces state width)
   
 «x:(* To indent no more than pp_max_indent, if one tries to open a block
    beyond pp_max_indent, then the block is rejected on the left
    by simulating a break. *)»
-«k:let» «v:pp_force_break_line» «v:state» =
+«k:let» «f:pp_force_break_line» «v:state» =
   «k:match» state.pp_format_stack «k:with»
   «:fsharp-ui-operator-face:|» Format_elem (bl_ty, width) :: _ ->
       «k:if» width > state.pp_space_left
@@ -287,7 +287,7 @@
   «:fsharp-ui-operator-face:|» [] -> pp_output_newline state
   
 «x:(* To skip a token, if the previous line has been broken. *)»
-«k:let» «v:pp_skip_token» «v:state» =
+«k:let» «f:pp_skip_token» «v:state» =
   «x:(* When calling pp_skip_token the queue cannot be empty. *)»
   «k:match» take_queue state.pp_queue «k:with»
   «:fsharp-ui-operator-face:|» { elem_size = size; length = len; token = _ } ->
@@ -300,7 +300,7 @@
 
  **************************************************************)»
 «x:(* To format a token. *)»
-«k:let» «v:format_pp_token» «v:state» «v:size» =
+«k:let» «f:format_pp_token» «v:state» «v:size» =
   «k:function»
   «:fsharp-ui-operator-face:|» Pp_text s ->
       (state.pp_space_left <- state.pp_space_left - size;
@@ -429,19 +429,19 @@
            advance_loop state)
         «k:else» ()
   
-«k:let» «v:advance_left» «v:state» = «k:try» advance_loop state «k:with» «:fsharp-ui-operator-face:|» Empty_queue -> ()
+«k:let» «f:advance_left» «v:state» = «k:try» advance_loop state «k:with» «:fsharp-ui-operator-face:|» Empty_queue -> ()
   
-«k:let» «v:enqueue_advance» «v:state» «v:tok» = (pp_enqueue state tok; advance_left state)
+«k:let» «f:enqueue_advance» «v:state» «v:tok» = (pp_enqueue state tok; advance_left state)
   
 «x:(* To enqueue a string : try to advance. *)»
-«k:let» «v:make_queue_elem» «v:size» «v:tok» «v:len» =
+«k:let» «f:make_queue_elem» «v:size» «v:tok» «v:len» =
   { elem_size = size; token = tok; length = len; }
   
-«k:let» «v:enqueue_string_as» «v:state» «v:size» «v:s» =
+«k:let» «f:enqueue_string_as» «v:state» «v:size» «v:s» =
   «k:let» «v:len» = int_of_size size
   «k:in» enqueue_advance state (make_queue_elem size (Pp_text s) len)
   
-«k:let» «v:enqueue_string» «v:state» «v:s» =
+«k:let» «f:enqueue_string» «v:state» «v:s» =
   «k:let» «v:len» = String.length s «k:in» enqueue_string_as state (size_of_int len) s
   
 «x:(* Routines for scan stack
@@ -454,13 +454,13 @@
 «x:(* Set size of blocks on scan stack:
    if ty = true then size of break is set else size of block is set;
    in each case pp_scan_stack is popped. *)»
-«k:let» «v:clear_scan_stack» «v:state» = state.pp_scan_stack <- scan_stack_bottom
+«k:let» «f:clear_scan_stack» «v:state» = state.pp_scan_stack <- scan_stack_bottom
   
 «x:(* Pattern matching on scan stack is exhaustive,
    since scan_stack is never empty.
    Pattern matching on token in scan stack is also exhaustive,
    since scan_push is used on breaks and opening of boxes. *)»
-«k:let» «v:set_size» «v:state» «v:ty» =
+«k:let» «f:set_size» «v:state» «v:ty» =
   «k:match» state.pp_scan_stack «k:with»
   «:fsharp-ui-operator-face:|» Scan_elem (left_tot,
       (({ elem_size = size; token = tok; length = _ } «k:as» queue_elem))) :: t
@@ -493,7 +493,7 @@
   
 «x:(* scan_stack is never empty. *)»
 «x:(* Push a token on scan stack. If b is true set_size is called. *)»
-«k:let» «v:scan_push» «v:state» «v:b» «v:tok» =
+«k:let» «f:scan_push» «v:state» «v:b» «v:tok» =
   (pp_enqueue state tok;
    «k:if» b «k:then» set_size state «k:true» «k:else» ();
    state.pp_scan_stack <-
@@ -502,7 +502,7 @@
 «x:(* To open a new block :
    the user may set the depth bound pp_max_boxes
    any text nested deeper is printed as the ellipsis string. *)»
-«k:let» «v:pp_open_box_gen» «v:state» «v:indent» «v:br_ty» =
+«k:let» «f:pp_open_box_gen» «v:state» «v:indent» «v:br_ty» =
   (state.pp_curr_depth <- state.pp_curr_depth + 1;
    «k:if» state.pp_curr_depth < state.pp_max_boxes
    «k:then»
@@ -516,10 +516,10 @@
      «k:else» ())
   
 «x:(* The box which is always opened. *)»
-«k:let» «v:pp_open_sys_box» «v:state» = pp_open_box_gen state 0 Pp_hovbox
+«k:let» «f:pp_open_sys_box» «v:state» = pp_open_box_gen state 0 Pp_hovbox
   
 «x:(* Close a block, setting sizes of its sub blocks. *)»
-«k:let» «v:pp_close_box» «v:state» () =
+«k:let» «f:pp_close_box» «v:state» () =
   «k:if» state.pp_curr_depth > 1
   «k:then»
     («k:if» state.pp_curr_depth < state.pp_max_boxes
@@ -533,7 +533,7 @@
   «k:else» ()
   
 «x:(* Open a tag, pushing it on the tag stack. *)»
-«k:let» «v:pp_open_tag» «v:state» «v:tag_name» =
+«k:let» «f:pp_open_tag» «v:state» «v:tag_name» =
   («k:if» state.pp_print_tags
    «k:then»
      (state.pp_tag_stack <- tag_name :: state.pp_tag_stack;
@@ -547,7 +547,7 @@
    «k:else» ())
   
 «x:(* Close a tag, popping it from the tag stack. *)»
-«k:let» «v:pp_close_tag» «v:state» () =
+«k:let» «f:pp_close_tag» «v:state» () =
   («k:if» state.pp_mark_tags
    «k:then»
      pp_enqueue state
@@ -562,18 +562,18 @@
    «k:else» ())
   
 «x:(* No more tag to close. *)»
-«k:let» «v:pp_set_print_tags» «v:state» «v:b» = state.pp_print_tags <- b
+«k:let» «f:pp_set_print_tags» «v:state» «v:b» = state.pp_print_tags <- b
   
-«k:let» «v:pp_set_mark_tags» «v:state» «v:b» = state.pp_mark_tags <- b
+«k:let» «f:pp_set_mark_tags» «v:state» «v:b» = state.pp_mark_tags <- b
   
-«k:let» «v:pp_get_print_tags» «v:state» () = state.pp_print_tags
+«k:let» «f:pp_get_print_tags» «v:state» () = state.pp_print_tags
   
-«k:let» «v:pp_get_mark_tags» «v:state» () = state.pp_mark_tags
+«k:let» «f:pp_get_mark_tags» «v:state» () = state.pp_mark_tags
   
-«k:let» «v:pp_set_tags» «v:state» «v:b» =
+«k:let» «f:pp_set_tags» «v:state» «v:b» =
   (pp_set_print_tags state b; pp_set_mark_tags state b)
   
-«k:let» «v:pp_get_formatter_tag_functions» «v:state» () =
+«k:let» «f:pp_get_formatter_tag_functions» «v:state» () =
   {
     mark_open_tag = state.pp_mark_open_tag;
     mark_close_tag = state.pp_mark_close_tag;
@@ -581,7 +581,7 @@
     print_close_tag = state.pp_print_close_tag;
   }
   
-«k:let» «v:pp_set_formatter_tag_functions» «v:state»
+«k:let» «f:pp_set_formatter_tag_functions» «v:state»
                                    {
                                      «v:mark_open_tag» = mot;
                                      mark_close_tag = mct;
@@ -594,7 +594,7 @@
    state.pp_print_close_tag <- pct)
   
 «x:(* Initialize pretty-printer. *)»
-«k:let» «v:pp_rinit» «v:state» =
+«k:let» «f:pp_rinit» «v:state» =
   (pp_clear_queue state;
    clear_scan_stack state;
    state.pp_format_stack <- [];
@@ -607,7 +607,7 @@
    pp_open_sys_box state)
   
 «x:(* Flushing pretty-printer queue. *)»
-«k:let» «v:pp_flush_queue» «v:state» «v:b» =
+«k:let» «f:pp_flush_queue» «v:state» «v:b» =
   («k:while» state.pp_curr_depth > 1 «k:do» pp_close_box state () «k:done»;
    state.pp_right_total <- pp_infinity;
    advance_left state;
@@ -620,52 +620,52 @@
 
  **************************************************************)»
 «x:(* To format a string. *)»
-«k:let» «v:pp_print_as_size» «v:state» «v:size» «v:s» =
+«k:let» «f:pp_print_as_size» «v:state» «v:size» «v:s» =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then» enqueue_string_as state size s
   «k:else» ()
   
-«k:let» «v:pp_print_as» «v:state» «v:isize» «v:s» = pp_print_as_size state (size_of_int isize) s
+«k:let» «f:pp_print_as» «v:state» «v:isize» «v:s» = pp_print_as_size state (size_of_int isize) s
   
-«k:let» «v:pp_print_string» «v:state» «v:s» = pp_print_as state (String.length s) s
+«k:let» «f:pp_print_string» «v:state» «v:s» = pp_print_as state (String.length s) s
   
 «x:(* To format an integer. *)»
-«k:let» «v:pp_print_int» «v:state» «v:i» = pp_print_string state (string_of_int i)
+«k:let» «f:pp_print_int» «v:state» «v:i» = pp_print_string state (string_of_int i)
   
 «x:(* To format a float. *)»
-«k:let» «v:pp_print_float» «v:state» «v:f» = pp_print_string state (string_of_float f)
+«k:let» «f:pp_print_float» «v:state» «v:f» = pp_print_string state (string_of_float f)
   
 «x:(* To format a boolean. *)»
-«k:let» «v:pp_print_bool» «v:state» «v:b» = pp_print_string state (string_of_bool b)
+«k:let» «f:pp_print_bool» «v:state» «v:b» = pp_print_string state (string_of_bool b)
   
 «x:(* To format a char. *)»
-«k:let» «v:pp_print_char» «v:state» («v:c» : «t:char») =
+«k:let» «f:pp_print_char» «v:state» («v:c» : «t:char») =
     pp_print_as state 1 (string c)
   
 «x:(* Opening boxes. *)»
 «k:let» «k:rec» «f:pp_open_hbox» «v:state» () = pp_open_box_gen state 0 Pp_hbox
-«k:and» «v:pp_open_vbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_vbox
-«k:and» «v:pp_open_hvbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_hvbox
-«k:and» «v:pp_open_hovbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_hovbox
-«k:and» «v:pp_open_box» «v:state» «v:indent» = pp_open_box_gen state indent Pp_box
+«k:and» «f:pp_open_vbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_vbox
+«k:and» «f:pp_open_hvbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_hvbox
+«k:and» «f:pp_open_hovbox» «v:state» «v:indent» = pp_open_box_gen state indent Pp_hovbox
+«k:and» «f:pp_open_box» «v:state» «v:indent» = pp_open_box_gen state indent Pp_box
   
 «x:(* Print a new line after printing all queued text
    (same for print_flush but without a newline). *)»
 «k:let» «k:rec» «f:pp_print_newline» «v:state» () =
     pp_flush_queue state «k:true»
     state.pp_out_flush ()
-«k:and» «v:pp_print_flush» «v:state» () =
+«k:and» «f:pp_print_flush» «v:state» () =
     pp_flush_queue state «k:false»
     state.pp_out_flush ()
   
 «x:(* To get a newline when one does not want to close the current block. *)»
-«k:let» «v:pp_force_newline» «v:state» () =
+«k:let» «f:pp_force_newline» «v:state» () =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then» enqueue_advance state (make_queue_elem (size_of_int 0) Pp_newline 0)
   «k:else» ()
   
 «x:(* To format something if the line has just been broken. *)»
-«k:let» «v:pp_print_if_newline» «v:state» () =
+«k:let» «f:pp_print_if_newline» «v:state» () =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then»
     enqueue_advance state (make_queue_elem (size_of_int 0) Pp_if_newline 0)
@@ -675,7 +675,7 @@
    If line is broken then offset is added to the indentation of the current
    block else (the value of) width blanks are printed.
    To do (?) : add a maximum width and offset value. *)»
-«k:let» «v:pp_print_break» «v:state» «v:width» «v:offset» =
+«k:let» «f:pp_print_break» «v:state» «v:width» «v:offset» =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then»
     («k:let» elem =
@@ -685,10 +685,10 @@
   «k:else» ()
   
 «k:let» «k:rec» «f:pp_print_space» «v:state» () = pp_print_break state 1 0
-«k:and» «v:pp_print_cut» «v:state» () = pp_print_break state 0 0
+«k:and» «f:pp_print_cut» «v:state» () = pp_print_break state 0 0
   
 «x:(* Tabulation boxes. *)»
-«k:let» «v:pp_open_tbox» «v:state» () =
+«k:let» «f:pp_open_tbox» «v:state» () =
   (state.pp_curr_depth <- state.pp_curr_depth + 1;
    «k:if» state.pp_curr_depth < state.pp_max_boxes
    «k:then»
@@ -698,7 +698,7 @@
    «k:else» ())
   
 «x:(* Close a tabulation block. *)»
-«k:let» «v:pp_close_tbox» «v:state» () =
+«k:let» «f:pp_close_tbox» «v:state» () =
   «k:if» state.pp_curr_depth > 1
   «k:then»
     «k:if» state.pp_curr_depth < state.pp_max_boxes
@@ -711,7 +711,7 @@
   «k:else» ()
   
 «x:(* Print a tabulation break. *)»
-«k:let» «v:pp_print_tbreak» «v:state» «v:width» «v:offset» =
+«k:let» «f:pp_print_tbreak» «v:state» «v:width» «v:offset» =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then»
     («k:let» elem =
@@ -720,9 +720,9 @@
      «k:in» scan_push state «k:true» elem)
   «k:else» ()
   
-«k:let» «v:pp_print_tab» «v:state» () = pp_print_tbreak state 0 0
+«k:let» «f:pp_print_tab» «v:state» () = pp_print_tbreak state 0 0
   
-«k:let» «v:pp_set_tab» «v:state» () =
+«k:let» «f:pp_set_tab» «v:state» () =
   «k:if» state.pp_curr_depth < state.pp_max_boxes
   «k:then»
     («k:let» elem = make_queue_elem (size_of_int 0) Pp_stab 0
@@ -735,21 +735,21 @@
 
  **************************************************************)»
 «x:(* Fit max_boxes. *)»
-«k:let» «v:pp_set_max_boxes» «v:state» «v:n» = «k:if» n > 1 «k:then» state.pp_max_boxes <- n «k:else» ()
+«k:let» «f:pp_set_max_boxes» «v:state» «v:n» = «k:if» n > 1 «k:then» state.pp_max_boxes <- n «k:else» ()
   
 «x:(* To know the current maximum number of boxes allowed. *)»
-«k:let» «v:pp_get_max_boxes» «v:state» () = state.pp_max_boxes
+«k:let» «f:pp_get_max_boxes» «v:state» () = state.pp_max_boxes
   
-«k:let» «v:pp_over_max_boxes» «v:state» () = state.pp_curr_depth = state.pp_max_boxes
+«k:let» «f:pp_over_max_boxes» «v:state» () = state.pp_curr_depth = state.pp_max_boxes
   
 «x:(* Ellipsis. *)»
 «k:let» «k:rec» «f:pp_set_ellipsis_text» «v:state» «v:s» = state.pp_ellipsis <- s
-«k:and» «v:pp_get_ellipsis_text» «v:state» () = state.pp_ellipsis
+«k:and» «f:pp_get_ellipsis_text» «v:state» () = state.pp_ellipsis
   
 «x:(* To set the margin of pretty-printer. *)»
-«k:let» «v:pp_limit» «v:n» = «k:if» n < pp_infinity «k:then» n «k:else» pred pp_infinity
+«k:let» «f:pp_limit» «v:n» = «k:if» n < pp_infinity «k:then» n «k:else» pred pp_infinity
   
-«k:let» «v:pp_set_min_space_left» «v:state» «v:n» =
+«k:let» «f:pp_set_min_space_left» «v:state» «v:n» =
   «k:if» n >= 1
   «k:then»
     («k:let» n = pp_limit n
@@ -762,12 +762,12 @@
 «x:(* Initially, we have :
   pp_max_indent = pp_margin - pp_min_space_left, and
   pp_space_left = pp_margin. *)»
-«k:let» «v:pp_set_max_indent» «v:state» «v:n» =
+«k:let» «f:pp_set_max_indent» «v:state» «v:n» =
   pp_set_min_space_left state (state.pp_margin - n)
   
-«k:let» «v:pp_get_max_indent» «v:state» () = state.pp_max_indent
+«k:let» «f:pp_get_max_indent» «v:state» () = state.pp_max_indent
   
-«k:let» «v:pp_set_margin» «v:state» «v:n» =
+«k:let» «f:pp_set_margin» «v:state» «v:n» =
   «k:if» n >= 1
   «k:then»
     («k:let» n = pp_limit n
@@ -788,7 +788,7 @@
         «k:in» «x:(* Rebuild invariants. *)» pp_set_max_indent state new_max_indent))
   «k:else» ()
   
-«k:let» «v:pp_get_margin» «v:state» () = state.pp_margin
+«k:let» «f:pp_get_margin» «v:state» () = state.pp_margin
   
 «k:type» formatter_out_functions = {
     out_string : «t:string» -> int -> int -> unit;
@@ -797,7 +797,7 @@
     out_spaces : «t:int» -> unit
   }
 
-«k:let» «v:pp_set_formatter_out_functions» «v:state»
+«k:let» «f:pp_set_formatter_out_functions» «v:state»
                                    {
                                      «v:out_string» = f;
                                      out_flush = g;
@@ -809,7 +809,7 @@
     state.pp_out_newline <- h
     state.pp_out_spaces <- i
   
-«k:let» «v:pp_get_formatter_out_functions» «v:state» () =
+«k:let» «f:pp_get_formatter_out_functions» «v:state» () =
   {
     out_string = state.pp_out_string;
     out_flush = state.pp_out_flush;
@@ -817,26 +817,26 @@
     out_spaces = state.pp_out_spaces;
   }
   
-«k:let» «v:pp_set_formatter_output_functions» «v:state» «v:f» «v:g» =
+«k:let» «f:pp_set_formatter_output_functions» «v:state» «v:f» «v:g» =
   (state.pp_out_string <- f; state.pp_out_flush <- g)
   
-«k:let» «v:pp_get_formatter_output_functions» «v:state» () =
+«k:let» «f:pp_get_formatter_output_functions» «v:state» () =
     state.pp_out_string, state.pp_out_flush
   
 «m://»«x:let pp_set_all_formatter_output_functions state ~out:f ~flush:g ~newline:h ~spaces:i =
-»«k:let» «v:pp_set_all_formatter_output_functions» «v:state» «v:f» «v:g» «v:h» «v:i» =
+»«k:let» «f:pp_set_all_formatter_output_functions» «v:state» «v:f» «v:g» «v:h» «v:i» =
     pp_set_formatter_output_functions state f g
     state.pp_out_newline <- h
     state.pp_out_spaces <- i
   
-«k:let» «v:pp_get_all_formatter_output_functions» «v:state» () =
+«k:let» «f:pp_get_all_formatter_output_functions» «v:state» () =
     state.pp_out_string,
     state.pp_out_flush,
     state.pp_out_newline,
     state.pp_out_spaces
   
 «x:(* Default function to output new lines. *)»
-«k:let» «v:display_newline» «v:state» () = state.pp_out_string «s:"\n"» 0 1
+«k:let» «f:display_newline» «v:state» () = state.pp_out_string «s:"\n"» 0 1
   
 «x:(* Default function to output spaces. *)»
 «k:let» «v:blank_line» = String.make 80 «s:' '»
@@ -852,7 +852,7 @@
 »«k:let» «k:private» «v:output» «v:oc» («v:buf» : «t:string») («v:pos» : «t:int») («v:len» : «t:int») =
     output_string oc (buf.Substring (pos, len))
 
-«k:let» «v:pp_set_formatter_out_channel» «v:state» «v:os» =
+«k:let» «f:pp_set_formatter_out_channel» «v:state» «v:os» =
    state.pp_out_string <- output os
    state.pp_out_flush <- («k:fun» () -> flush os)
    state.pp_out_newline <- display_newline state
@@ -863,15 +863,15 @@
   Creation of specific formatters
 
  **************************************************************)»
-«k:let» «v:default_pp_mark_open_tag» «v:s» = «s:"<"» ^ (s ^ «s:">"»)
+«k:let» «f:default_pp_mark_open_tag» «v:s» = «s:"<"» ^ (s ^ «s:">"»)
   
-«k:let» «v:default_pp_mark_close_tag» «v:s» = «s:"</"» ^ (s ^ «s:">"»)
+«k:let» «f:default_pp_mark_close_tag» «v:s» = «s:"</"» ^ (s ^ «s:">"»)
   
 «k:let» «v:default_pp_print_open_tag» = ignore
   
 «k:let» «v:default_pp_print_close_tag» = ignore
   
-«k:let» «v:pp_make_formatter» «v:f» «v:g» «v:h» «v:i» =
+«k:let» «f:pp_make_formatter» «v:f» «v:g» «v:h» «v:i» =
   «x:(* The initial state of the formatter contains a dummy box. *)»
   «k:let» «v:pp_q» = make_queue () «k:in»
   «k:let» «v:sys_tok» =
@@ -911,17 +911,17 @@
        })
   
 «x:(* Make a formatter with default functions to output spaces and new lines. *)»
-«k:let» «v:make_formatter» «v:output» «v:flush» =
+«k:let» «f:make_formatter» «v:output» «v:flush» =
   «k:let» «v:ppf» = pp_make_formatter output flush ignore ignore
   «k:in»
     (ppf.pp_out_newline <- display_newline ppf;
      ppf.pp_out_spaces <- display_blanks ppf;
      ppf)
   
-«k:let» «v:formatter_of_out_channel» «v:oc» =
+«k:let» «f:formatter_of_out_channel» «v:oc» =
   make_formatter (output oc) («k:fun» () -> flush oc)
   
-«k:let» «v:formatter_of_buffer» «v:b» = make_formatter (Buffer.add_substring b) ignore
+«k:let» «f:formatter_of_buffer» «v:b» = make_formatter (Buffer.add_substring b) ignore
   
 «k:let» «v:stdbuf» = Buffer.create 512
   
@@ -930,7 +930,7 @@
 «k:and» «v:err_formatter» = formatter_of_out_channel Pervasives.stderr
 «k:and» «v:str_formatter» = formatter_of_buffer stdbuf
   
-«k:let» «v:flush_str_formatter» () =
+«k:let» «f:flush_str_formatter» () =
   (pp_flush_queue str_formatter «k:false»;
    «k:let» «v:s» = Buffer.contents stdbuf «k:in» (Buffer.reset stdbuf; s))
   
@@ -974,7 +974,7 @@
 «k:and» «v:over_max_boxes» = pp_over_max_boxes std_formatter
 «k:and» «v:set_ellipsis_text» = pp_set_ellipsis_text std_formatter
 «k:and» «v:get_ellipsis_text» = pp_get_ellipsis_text std_formatter
-«k:and» «v:set_formatter_out_channel» («v:channel» : «t:out_channel») =
+«k:and» «f:set_formatter_out_channel» («v:channel» : «t:out_channel») =
     pp_set_formatter_out_channel std_formatter channel
 «k:and» «v:set_formatter_out_functions» =
   pp_set_formatter_out_functions std_formatter
@@ -1009,7 +1009,7 @@
   
 «x:(* Error messages when processing formats. *)»
 «x:(* Trailer: giving up at character number ... *)»
-«k:let» «v:giving_up» «v:mess» «v:fmt» «v:i» =
+«k:let» «f:giving_up» «v:mess» «v:fmt» «v:i» =
     sprintf «s:"Format.fprintf: %s ``%s'', giving up at character number %d%s"»
         mess (Sformat.to_string fmt) i
         («k:if» i < Sformat.length fmt
@@ -1017,36 +1017,36 @@
          «k:else» sprintf «s:"%c"» «s:'.'»)
   
 «x:(* When an invalid format deserves a special error explanation. *)»
-«k:let» «v:format_invalid_arg» «v:mess» «v:fmt» «v:i» = invalid_arg (giving_up mess fmt i)
+«k:let» «f:format_invalid_arg» «v:mess» «v:fmt» «v:i» = invalid_arg (giving_up mess fmt i)
   
 «x:(* Standard invalid format. *)»
-«k:let» «v:invalid_format» «v:fmt» «v:i» = format_invalid_arg «s:"bad format"» fmt i
+«k:let» «f:invalid_format» «v:fmt» «v:i» = format_invalid_arg «s:"bad format"» fmt i
   
 «x:(* Cannot find a valid integer into that format. *)»
-«k:let» «v:invalid_integer» «v:fmt» «v:i» =
+«k:let» «f:invalid_integer» «v:fmt» «v:i» =
   invalid_arg (giving_up «s:"bad integer specification"» fmt i)
   
 «x:(* Finding an integer size out of a sub-string of the format. *)»
-«k:let» «v:format_int_of_string» «v:fmt» «v:i» «v:s» =
+«k:let» «f:format_int_of_string» «v:fmt» «v:i» «v:s» =
   «k:let» «v:sz» = «k:try» int_of_string s «k:with» «:fsharp-ui-operator-face:|» Failure _ -> invalid_integer fmt i
   «k:in» size_of_int sz
   
 «x:(* Getting strings out of buffers. *)»
-«k:let» «v:get_buffer_out» «v:b» = «k:let» s = Buffer.contents b «k:in» (Buffer.reset b; s)
+«k:let» «f:get_buffer_out» «v:b» = «k:let» s = Buffer.contents b «k:in» (Buffer.reset b; s)
   
 «x:(* [ppf] is supposed to be a pretty-printer that outputs to buffer [b]:
    to extract the contents of [ppf] as a string we flush [ppf] and get the
    string out of [b]. *)»
-«k:let» «v:string_out» «v:b» «v:ppf» = (pp_flush_queue ppf «k:false»; get_buffer_out b)
+«k:let» «f:string_out» «v:b» «v:ppf» = (pp_flush_queue ppf «k:false»; get_buffer_out b)
   
 «x:(* Applies [printer] to a formatter that outputs on a fresh buffer,
    then returns the resulting material. *)»
-«k:let» «v:exstring» «v:printer» «v:arg» =
+«k:let» «f:exstring» «v:printer» «v:arg» =
   «k:let» «v:b» = Buffer.create 512 «k:in»
   «k:let» «v:ppf» = formatter_of_buffer b «k:in» (printer ppf arg; string_out b ppf)
   
 «x:(* To turn out a character accumulator into the proper string result. *)»
-«k:let» «v:implode_rev» «v:s0» = «k:function»
+«k:let» «f:implode_rev» «v:s0» = «k:function»
   «:fsharp-ui-operator-face:|» [] -> s0
   «:fsharp-ui-operator-face:|» l -> String.concat «s:""» (List.rev (s0 :: l))
   
@@ -1060,10 +1060,10 @@
    according to the format string.
    Regular [fprintf]-like functions of this module are obtained via partial
    applications of [mkprintf]. *)»
-«k:let» «v:mkprintf» «v:to_s» «v:get_out» =
+«k:let» «f:mkprintf» «v:to_s» «v:get_out» =
   «k:let» «k:rec» «f:kprintf» «v:k» «v:fmt» =
     «k:let» «v:len» = Sformat.length fmt «k:in»
-    «k:let» «v:kpr» «v:fmt» «v:v» =
+    «k:let» «f:kpr» «v:fmt» «v:v» =
       «k:let» «v:ppf» = get_out fmt «k:in»
       «k:let» «v:print_as» = ref None «k:in»
       «k:let» «k:rec» «f:pp_print_as_char» «v:c» =
@@ -1071,7 +1071,7 @@
         «:fsharp-ui-operator-face:|» None -> pp_print_char ppf c
         «:fsharp-ui-operator-face:|» Some size ->
             (pp_print_as_size ppf size (String.make 1 c); print_as := None)
-      «k:and» «v:pp_print_as_string» «v:s» =
+      «k:and» «f:pp_print_as_string» «v:s» =
         «k:match» !print_as «k:with»
         «:fsharp-ui-operator-face:|» None -> pp_print_string ppf s
         «:fsharp-ui-operator-face:|» Some size -> (pp_print_as_size ppf size s; print_as := None) «k:in»
@@ -1101,29 +1101,29 @@
                     «:fsharp-ui-operator-face:|» «s:'\n'» -> (pp_force_newline ppf (); doprn n (succ i))
                     «:fsharp-ui-operator-face:|» «s:';'» -> do_pp_break ppf n (succ i)
                     «:fsharp-ui-operator-face:|» «s:'<'» ->
-                        «k:let» «v:got_size» «v:size» «v:n» «v:i» =
+                        «k:let» «f:got_size» «v:size» «v:n» «v:i» =
                           (print_as := Some size; doprn n (skip_gt i))
                         «k:in» get_int n (succ i) got_size
                     «:fsharp-ui-operator-face:|» («s:'@'» «:fsharp-ui-operator-face:|» «s:'%'» «k:as» c) ->
                         (pp_print_as_char c; doprn n (succ i))
                     «:fsharp-ui-operator-face:|» _ -> invalid_format fmt i)
            «:fsharp-ui-operator-face:|» c -> (pp_print_as_char c; doprn n (succ i)))
-      «k:and» «v:cont_s» «v:n» «v:s» «v:i» = (pp_print_as_string s; doprn n i)
-      «k:and» «v:cont_a» «v:n» «v:printer» «v:arg» «v:i» =
+      «k:and» «f:cont_s» «v:n» «v:s» «v:i» = (pp_print_as_string s; doprn n i)
+      «k:and» «f:cont_a» «v:n» «v:printer» «v:arg» «v:i» =
         («k:if» to_s
          «k:then»
            pp_print_as_string
              ((Obj.magic printer : «t:unit» -> _ -> string) () arg)
          «k:else» printer ppf arg;
          doprn n i)
-      «k:and» «v:cont_t» «v:n» «v:printer» «v:i» =
+      «k:and» «f:cont_t» «v:n» «v:printer» «v:i» =
         («k:if» to_s
          «k:then» pp_print_as_string ((Obj.magic printer : «t:unit» -> string) ())
          «k:else» printer ppf;
          doprn n i)
-      «k:and» «v:cont_f» «v:n» «v:i» = (pp_print_flush ppf (); doprn n i)
-      «k:and» «v:cont_m» «v:n» «v:sfmt» «v:i» = kprintf (Obj.magic («k:fun» «v:_» -> doprn n i)) sfmt
-      «k:and» «v:get_int» «v:n» «v:i» «v:c» =
+      «k:and» «f:cont_f» «v:n» «v:i» = (pp_print_flush ppf (); doprn n i)
+      «k:and» «f:cont_m» «v:n» «v:sfmt» «v:i» = kprintf (Obj.magic («k:fun» «v:_» -> doprn n i)) sfmt
+      «k:and» «f:get_int» «v:n» «v:i» «v:c» =
         «k:if» i >= len
         «k:then» invalid_integer fmt i
         «k:else»
@@ -1131,10 +1131,10 @@
            «:fsharp-ui-operator-face:|» «s:' '» -> get_int n (succ i) c
            «:fsharp-ui-operator-face:|» «s:'%'» ->
                «k:let» «k:rec» «f:cont_s» «v:n» «v:s» «v:i» = c (format_int_of_string fmt i s) n i
-               «k:and» «v:cont_a» «v:_n» «v:_printer» «v:_arg» «v:i» = invalid_integer fmt i
-               «k:and» «v:cont_t» «v:_n» «v:_printer» «v:i» = invalid_integer fmt i
-               «k:and» «v:cont_f» «v:_n» «v:i» = invalid_integer fmt i
-               «k:and» «v:cont_m» «v:_n» «v:_sfmt» «v:i» = invalid_integer fmt i
+               «k:and» «f:cont_a» «v:_n» «v:_printer» «v:_arg» «v:i» = invalid_integer fmt i
+               «k:and» «f:cont_t» «v:_n» «v:_printer» «v:i» = invalid_integer fmt i
+               «k:and» «f:cont_f» «v:_n» «v:i» = invalid_integer fmt i
+               «k:and» «f:cont_m» «v:_n» «v:_sfmt» «v:i» = invalid_integer fmt i
                «k:in»
                  Tformat.scan_format fmt v n i cont_s cont_a cont_t cont_f
                    cont_m
@@ -1158,7 +1158,7 @@
                              «k:in» format_int_of_string fmt j s)
                         «k:in» c size n j)
                «k:in» get i)
-      «k:and» «v:skip_gt» «v:i» =
+      «k:and» «f:skip_gt» «v:i» =
         «k:if» i >= len
         «k:then» invalid_format fmt i
         «k:else»
@@ -1166,7 +1166,7 @@
            «:fsharp-ui-operator-face:|» «s:' '» -> skip_gt (succ i)
            «:fsharp-ui-operator-face:|» «s:'>'» -> succ i
            «:fsharp-ui-operator-face:|» _ -> invalid_format fmt i)
-      «k:and» «v:get_box_kind» «v:i» =
+      «k:and» «f:get_box_kind» «v:i» =
         «k:if» i >= len
         «k:then» (Pp_box, i)
         «k:else»
@@ -1195,7 +1195,7 @@
            «:fsharp-ui-operator-face:|» «s:'b'» -> (Pp_box, (succ i))
            «:fsharp-ui-operator-face:|» «s:'v'» -> (Pp_vbox, (succ i))
            «:fsharp-ui-operator-face:|» _ -> (Pp_box, i))
-      «k:and» «v:get_tag_name» «v:n» «v:i» «v:c» =
+      «k:and» «f:get_tag_name» «v:n» «v:i» «v:c» =
         «k:let» «k:rec» «f:get» «v:accu» «v:n» «v:i» «v:j» =
           «k:if» j >= len
           «k:then»
@@ -1213,28 +1213,28 @@
              «:fsharp-ui-operator-face:|» «s:'%'» ->
                  «k:let» «v:s0» = Sformat.sub fmt (Sformat.index_of_int i) (j - i) «k:in»
                  «k:let» «k:rec» «f:cont_s» «v:n» «v:s» «v:i» = get (s :: s0 :: accu) n i i
-                 «k:and» «v:cont_a» «v:n» «v:printer» «v:arg» «v:i» =
+                 «k:and» «f:cont_a» «v:n» «v:printer» «v:arg» «v:i» =
                    «k:let» «v:s» =
                      «k:if» to_s
                      «k:then» (Obj.magic printer : «t:unit» -> _ -> string) () arg
                      «k:else» exstring printer arg
                    «k:in» get (s :: s0 :: accu) n i i
-                 «k:and» «v:cont_t» «v:n» «v:printer» «v:i» =
+                 «k:and» «f:cont_t» «v:n» «v:printer» «v:i» =
                    «k:let» «v:s» =
                      «k:if» to_s
                      «k:then» (Obj.magic printer : «t:unit» -> string) ()
                      «k:else» exstring («k:fun» «v:ppf» () -> printer ppf) ()
                    «k:in» get (s :: s0 :: accu) n i i
-                 «k:and» «v:cont_f» «v:_n» «v:i» =
+                 «k:and» «f:cont_f» «v:_n» «v:i» =
                    format_invalid_arg «s:"bad tag name specification"» fmt i
-                 «k:and» «v:cont_m» «v:_n» «v:_sfmt» «v:i» =
+                 «k:and» «f:cont_m» «v:_n» «v:_sfmt» «v:i» =
                    format_invalid_arg «s:"bad tag name specification"» fmt i
                  «k:in»
                    Tformat.scan_format fmt v n j cont_s cont_a cont_t cont_f
                      cont_m
              «:fsharp-ui-operator-face:|» _ -> get accu n i (succ j))
         «k:in» get [] n i i
-      «k:and» «v:do_pp_break» «v:ppf» «v:n» «v:i» =
+      «k:and» «f:do_pp_break» «v:ppf» «v:n» «v:i» =
         «k:if» i >= len
         «k:then» (pp_print_space ppf (); doprn n i)
         «k:else»
@@ -1242,31 +1242,31 @@
            «:fsharp-ui-operator-face:|» «s:'<'» ->
                «k:let» «k:rec» «f:got_nspaces» «v:nspaces» «v:n» «v:i» =
                  get_int n i (got_offset nspaces)
-               «k:and» «v:got_offset» «v:nspaces» «v:offset» «v:n» «v:i» =
+               «k:and» «f:got_offset» «v:nspaces» «v:offset» «v:n» «v:i» =
                  (pp_print_break ppf (int_of_size nspaces)
                     (int_of_size offset);
                   doprn n (skip_gt i))
                «k:in» get_int n (succ i) got_nspaces
            «:fsharp-ui-operator-face:|» _c -> (pp_print_space ppf (); doprn n i))
-      «k:and» «v:do_pp_open_box» «v:ppf» «v:n» «v:i» =
+      «k:and» «f:do_pp_open_box» «v:ppf» «v:n» «v:i» =
         «k:if» i >= len
         «k:then» (pp_open_box_gen ppf 0 Pp_box; doprn n i)
         «k:else»
           («k:match» Sformat.get fmt i «k:with»
            «:fsharp-ui-operator-face:|» «s:'<'» ->
                «k:let» («v:kind», «v:i») = get_box_kind (succ i) «k:in»
-               «k:let» «v:got_size» «v:size» «v:n» «v:i» =
+               «k:let» «f:got_size» «v:size» «v:n» «v:i» =
                  (pp_open_box_gen ppf (int_of_size size) kind;
                   doprn n (skip_gt i))
                «k:in» get_int n i got_size
            «:fsharp-ui-operator-face:|» _c -> (pp_open_box_gen ppf 0 Pp_box; doprn n i))
-      «k:and» «v:do_pp_open_tag» «v:ppf» «v:n» «v:i» =
+      «k:and» «f:do_pp_open_tag» «v:ppf» «v:n» «v:i» =
         «k:if» i >= len
         «k:then» (pp_open_tag ppf «s:""»; doprn n i)
         «k:else»
           («k:match» Sformat.get fmt i «k:with»
            «:fsharp-ui-operator-face:|» «s:'<'» ->
-               «k:let» «v:got_name» «v:tag_name» «v:n» «v:i» =
+               «k:let» «f:got_name» «v:tag_name» «v:n» «v:i» =
                  (pp_open_tag ppf tag_name; doprn n (skip_gt i))
                «k:in» get_tag_name n (succ i) got_name
            «:fsharp-ui-operator-face:|» _c -> (pp_open_tag ppf «s:""»; doprn n i))
@@ -1279,34 +1279,34 @@
   Defining [fprintf] and various flavors of [fprintf].
 
  **************************************************************)»
-«k:let» «v:kfprintf» «v:k» «v:ppf» = mkprintf «k:false» («k:fun» «v:_» -> ppf) k
+«k:let» «f:kfprintf» «v:k» «v:ppf» = mkprintf «k:false» («k:fun» «v:_» -> ppf) k
   
-«k:let» «v:ikfprintf» «v:k» «v:ppf» = Tformat.kapr («k:fun» «v:_» «v:_» -> Obj.magic (k ppf))
+«k:let» «f:ikfprintf» «v:k» «v:ppf» = Tformat.kapr («k:fun» «v:_» «v:_» -> Obj.magic (k ppf))
   
-«k:let» «v:fprintf» «v:ppf» = kfprintf ignore ppf
+«k:let» «f:fprintf» «v:ppf» = kfprintf ignore ppf
   
-«k:let» «v:ifprintf» «v:ppf» = ikfprintf ignore ppf
+«k:let» «f:ifprintf» «v:ppf» = ikfprintf ignore ppf
   
-«k:let» «v:printf» «v:fmt» = fprintf std_formatter fmt
+«k:let» «f:printf» «v:fmt» = fprintf std_formatter fmt
   
-«k:let» «v:eprintf» «v:fmt» = fprintf err_formatter fmt
+«k:let» «f:eprintf» «v:fmt» = fprintf err_formatter fmt
   
-«k:let» «v:ksprintf» «v:k» =
+«k:let» «f:ksprintf» «v:k» =
   «k:let» «v:b» = Buffer.create 512 «k:in»
-  «k:let» «v:k» «v:ppf» = k (string_out b ppf)
+  «k:let» «f:k» «v:ppf» = k (string_out b ppf)
   «k:in» mkprintf «k:true» («k:fun» «v:_» -> formatter_of_buffer b) k
   
-«k:let» «v:sprintf» «v:fmt» = ksprintf («k:fun» «v:s» -> s) fmt
+«k:let» «f:sprintf» «v:fmt» = ksprintf («k:fun» «v:s» -> s) fmt
   
 «x:(**************************************************************
 
   Deprecated stuff.
 
  **************************************************************)»
-«k:let» «v:kbprintf» «v:k» «v:b» = mkprintf «k:false» («k:fun» «v:_» -> formatter_of_buffer b) k
+«k:let» «f:kbprintf» «v:k» «v:b» = mkprintf «k:false» («k:fun» «v:_» -> formatter_of_buffer b) k
   
 «x:(* Deprecated error prone function bprintf. *)»
-«k:let» «v:bprintf» «v:b» = «k:let» k ppf = pp_flush_queue ppf «k:false» «k:in» kbprintf k b
+«k:let» «f:bprintf» «v:b» = «k:let» «f:k» ppf = pp_flush_queue ppf «k:false» «k:in» kbprintf k b
   
 «x:(* Deprecated alias for ksprintf. *)»
 «k:let» «v:kprintf» = ksprintf

--- a/test/apps/RecordHighlighting/Test.fsx.faceup
+++ b/test/apps/RecordHighlighting/Test.fsx.faceup
@@ -1,26 +1,26 @@
-«k:type» RecordTest1 = { something: «t:int»
+«k:type» «t:RecordTest1» = { something: «t:int»
                      another: «t:string» }
 
-«k:type» RecordTest2 = { something :«t:int»; another :«t:string» }
+«k:type» «t:RecordTest2» = { something :«t:int»; another :«t:string» }
 
-«k:type» RecordTest3 = { something : «t:float»; another: «t:float»; third :«t:float»; }
+«k:type» «t:RecordTest3» = { something : «t:float»; another: «t:float»; third :«t:float»; }
 
-«k:type» RecordTest4 = {
+«k:type» «t:RecordTest4» = {
     something: «t:int»
     another: «t:string» }
 
-«k:type» RecordTest5 =
+«k:type» «t:RecordTest5» =
     { something: «t:int»
       another: «t:string» }
 
-«k:type» RecordTest6 =
+«k:type» «t:RecordTest6» =
     {
         something: «t:int»
         another: «t:string»
         third: «t:Option»«:fsharp-ui-generic-face:<int>»
     }
 
-«k:type» RecordTest7 =
+«k:type» «t:RecordTest7» =
     {
     something: «t:int»
     another: «t:string»

--- a/test/fsharp-mode-font-tests.el
+++ b/test/fsharp-mode-font-tests.el
@@ -120,10 +120,6 @@
     (should (not (string-match fsharp-constructor-regexp test-string-2)))))
 
 ;; Operators
-(ert-deftest fsharp-operator-active-pattern-regexp-test ()
-  (let ((test-string "(|Foo|Bar|)"))
-    (test-capture fsharp-operator-active-pattern-regexp test-string "(|" "|)")))
-
 (ert-deftest fsharp-operator-quote-regexp-test ()
   (let ((test-string "<@ SomeCode @>"))
     (test-capture fsharp-operator-quote-regexp test-string "<@" "@>")))


### PR DESCRIPTION
This PR cleans up some of the work from #114:

- Removes commented and dead code
- `eval-when-compile`s the main font-lock-keywords form
- Better font locking for active patterns
- Docstrings
- Naming