### PR TITLE
Don't change company-idle-delay

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -224,7 +224,6 @@
           company-backends
           company-auto-complete
           company-auto-complete-chars
-          company-idle-delay
           company-require-match
           company-tooltip-align-annotations))
 
@@ -255,7 +254,6 @@
   (add-to-list 'company-backends 'fsharp-ac/company-backend)
   (setq company-auto-complete 't)
   (setq company-auto-complete-chars ".")
-  (setq company-idle-delay 0.03)
   (setq company-require-match 'nil)
   (setq company-tooltip-align-annotations 't)
 


### PR DESCRIPTION
@nosami  I don't know about the rationale setting this to `0.03` secons in `fsharp-mode` buffers.

I often get a disruptive completion popup while  still typing. It is exacerbated by the fact that we use a `min-prefix-length` of `0`.

I would prefer not changing this `defcustom`  and let Users customize it if they want faster/slower settings.

Any options?

:fireworks: 