### PR TITLE
Fix FSAC hanging issue

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -146,7 +146,7 @@ since the last request."
         (fsharp-ac--log (format "Parsing \"%s\"\n" file))
         (process-send-string
          (fsharp-ac-completion-process (fsharp-ac--hostname file))
-         (format "parse \"%s\" %s\n%s<<EOF>>\n"
+         (format "parse \"%s\" %s\n%s\n<<EOF>>\n"
                  (fsharp-ac--localname file)
                  (if force-sync " sync" "")
                  (buffer-substring-no-properties (point-min) (point-max)))))


### PR DESCRIPTION
The protocol chatter sent to FSAC to parse some code goes like this:

```
parse "filename"
...F# code...
...F# code...
...F# code...
<<EOF>>
```

`<<EOF>>` is not an actual EOF, but literally the string `<<EOF>>`, which must be
preceded by a newline and followed by a newline.

The issue was that typing at the end of the buffer would cause the buffer's
contents to be sent to FSAC, but because the last byte of the buffer would not
be the conventional appended-at-save newline, FSAC would be sent this instead:

```
parse "filename"
...F# code...
...F# code...
...F# code...<<EOF>
```

...and thus continue waiting for input indefinitely, causing things like type
info and Flycheck to stop working.

Fixes #119.