### PR TITLE
Five minute tooltip timeout seems a tad long.

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -752,7 +752,7 @@ has requested a popup tooltip, display a popup."
 
 (defun fsharp-ac/show-popup (str)
   (if (display-graphic-p)
-      (pos-tip-show str nil nil nil 300)
+      (pos-tip-show str)
     ;; Use unoptimized calculation for popup, making it less likely to
     ;; wrap lines.
     (let ((popup-use-optimized-column-computation nil))


### PR DESCRIPTION
`pos-tip-show` function in pos-tip v0.4.5+ says that timeout is in seconds, and I think 300 is a bit on the long side. The default of five seconds seem more reasonable.