### PR TITLE
Improved logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
   - evm install $EVM_EMACS --use --skip
 
 env:
-  - EVM_EMACS=emacs-24.4-travis
-  - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-git-snapshot-travis
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: csharp
-sudo: false
+sudo: required
 
 before_install:
+  - sudo apt-get install -y fsharp
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - evm install $EVM_EMACS --use --skip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
 env:
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
-  - EVM_EMACS=emacs-git-snapshot-travis
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following features are under development:
 
 - Intelligent indentation
 
-Requires Emacs 24+, Mono 3.10.X and F# 3.0 or higher. Without F# 3.0 (or higher)
+Requires Emacs 25.1+, Mono 3.10.X and F# 3.0 or higher. Without F# 3.0 (or higher)
 the background compiler process will not function correctly.
 
 ## Build Status

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -26,6 +26,7 @@
 (with-no-warnings (require 'cl))
 (require 'tramp)
 (require 's)
+(require 'subr-x)
 (require 'dash)
 (require 'company)
 (require 'json)

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -147,7 +147,7 @@ ARGUMENTS to actually emit the message (if applicable)."
         (insert (format "%s%s: %s" tstr (if (and fn (not (string-empty-p fn))) (concat " (" fn ")") "") mstr))))))
 
 (defun log-psendstr (proc str)
-  (fsharp-ac--log str)
+  (fsharp-ac--log "%s" str)
   (process-send-string proc str))
 
 (defun fsharp-ac-parse-current-buffer (&optional force-sync)
@@ -164,7 +164,8 @@ since the last request."
     (save-restriction
       (let ((file (fsharp-ac--buffer-truename)))
         (widen)
-        (fsharp-ac--log (format "Parsing \"%s\"\n" file))
+        (
+         fsharp-ac--log "Parsing \"%s\"" file)
         (process-send-string
          (fsharp-ac-completion-process (fsharp-ac--hostname file))
          (format "parse \"%s\" %s\n%s\n<<EOF>>\n"
@@ -662,10 +663,10 @@ prevent usage errors being displayed by FSHARP-DOC-MODE."
       (when (numberp fsharp-ac-debug)
         (cond
          ((eq fsharp-ac-debug 1)
-          (fsharp-ac--log (format "%s ...\n" (buffer-substring (point-min) (min 100 eofloc)))))
+          (fsharp-ac--log "%s ..." (buffer-substring (point-min) (min 100 eofloc))))
 
          ((>= fsharp-ac-debug 2)
-          (fsharp-ac--log (format "%s\n" (buffer-substring (point-min) eofloc))))))
+          (fsharp-ac--log "%s" (buffer-substring (point-min) eofloc)))))
 
       (let ((json-array-type 'list)
             (json-object-type 'hash-table)
@@ -676,7 +677,7 @@ prevent usage errors being displayed by FSHARP-DOC-MODE."
                 (json-read)
               (delete-region (point-min) (1+ (point))))
           (error
-           (fsharp-ac--log (format "Malformed JSON: %s" (buffer-substring-no-properties (point-min) (point-max))))
+           (fsharp-ac--log "Malformed JSON: %s" (buffer-substring-no-properties (point-min) (point-max)))
 	   (delete-region (point-min) eofloc)
 	   (fsharp-ac--get-msg proc)))))))
 
@@ -694,9 +695,9 @@ prevent usage errors being displayed by FSHARP-DOC-MODE."
                 (/= (hash-table-count msg) 0))
       (let ((kind (gethash "Kind" msg))
             (data (gethash "Data" msg)))
-        (fsharp-ac--log (format "Received '%s' message of length %d\n"
-                                kind
-                                (hash-table-count msg)))
+        (fsharp-ac--log "Received '%s' message of length %d"
+                        kind
+                        (hash-table-count msg))
         (pcase kind
          ("error" (fsharp-ac-handle-process-error data))
          ("info" (when fsharp-ac-verbose (fsharp-ac-message-safely data)))


### PR DESCRIPTION
As discussed in [Improve *fsharp-debug* logging](https://github.com/fsharp/emacs-fsharp-mode/issues/132)

- Log caller-function (when (>= fsharp-ac-debug 3))                                                                                                                                                                
- Supply format string instead of already formatted string                                                                                                                                                         
- Human readable timestamps                                                                                                                                                                                        
- Ensure newline before log message    

I hope this will make debug logs more useful