### PR TITLE
fsharp-shift-region-[left,right]: change bindings to 'C-c <' and 'C-c >'

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -87,8 +87,8 @@
   (define-key fsharp-mode-map (kbd "M-n") 'next-error)
   (define-key fsharp-mode-map (kbd "M-p") 'previous-error)
 
-  (define-key fsharp-mode-map "\C-cl" 'fsharp-shift-region-left)
-  (define-key fsharp-mode-map "\C-cr" 'fsharp-shift-region-right)
+  (define-key fsharp-mode-map "\C-c<" 'fsharp-shift-region-left)
+  (define-key fsharp-mode-map "\C-c>" 'fsharp-shift-region-right)
 
   (define-key fsharp-mode-map "\C-m"      'fsharp-newline-and-indent)
   (define-key fsharp-mode-map "\C-c:"     'fsharp-guess-indent-offset)


### PR DESCRIPTION
These commands were bound to 'C-c l' and 'C-c r', keys conventionally
reserved for the user.

https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html

The choice of 'C-c <' and C-c >' is drawn from python-mode.

Resolves #135.