### PR TITLE
Disable flycheck and fsharp-doc-mode when fsharp-ac-intellisense-enab…

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -269,8 +269,10 @@
       (setq compile-command (fsharp-mode-choose-compile-command file))
       (fsharp-mode--load-with-binding file)))
 
-  (flycheck-mode 1)
-  (turn-on-fsharp-doc-mode)
+  (when fsharp-ac-intellisense-enabled
+    (flycheck-mode 1)
+    (turn-on-fsharp-doc-mode))
+
   (run-hooks 'fsharp-mode-hook))
 
 (defun fsharp-mode--load-with-binding (file)


### PR DESCRIPTION
…led is set to nil.

This is a fix for issue #138. Note that I am disabling **fsharp-doc-mode** as well when `fsharp-ac-intellisense-enabled` is set to `nil` since I believe it relies on a background intellisense process as well.

I ran the test suite before and after the change (`gmake test-all`) on FreeBSD 11 and all tests passed in both runs. I also used the mode once and the constant "Error: background intellisense process not running" messages were not appearing.