### PR TITLE
Add access control keywords to declaration regexes

### DIFF
--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -93,6 +93,7 @@ with initial value INITVALUE and optional DOCSTRING."
 (def-fsharp-compiled-var fsharp-function-def-regexp
   (concat "\\<\\(?:let\\|and\\|with\\)\\s-+"
           fsharp-inline-rec-regexp-noncapturing "?"
+          fsharp-access-control-regexp-noncapturing "*"
           (format "\\(%s\\)" fsharp-valid-identifier-regexp)
           "\\(?:\\s-+[A-Za-z_]\\|\\s-*(\\)" ;; matches function arguments or open-paren; unclear why 0-9 not in class
           ))
@@ -100,6 +101,7 @@ with initial value INITVALUE and optional DOCSTRING."
 (def-fsharp-compiled-var fsharp-pattern-function-regexp
   (concat "\\<\\(?:let\\|and\\)\\s-+"
           fsharp-inline-rec-regexp-noncapturing "?"
+          fsharp-access-control-regexp-noncapturing "*"
           (format "\\(%s\\)" fsharp-valid-identifier-regexp)
           "\\s-*=\\s-*function")
   "Matches an implicit matcher, eg let foo m = function | \"cat\" -> etc.")
@@ -107,7 +109,10 @@ with initial value INITVALUE and optional DOCSTRING."
 ;; Note that this regexp is used for iMenu. To font-lock active patterns, we
 ;; need to use an anchored match in fsharp-font-lock-keywords.
 (def-fsharp-compiled-var fsharp-active-pattern-regexp
-  "\\<\\(?:let\\|and\\)\\s-+\\(?:\\(?:inline\\|rec\\)\\s-+\\)?(\\(|[A-Za-z0-9_'|]+|\\))\\(?:\\s-+[A-Za-z_]\\|\\s-*(\\)")
+  (concat "\\<\\(?:let\\|and\\)\\s-+"
+          fsharp-inline-rec-regexp-noncapturing "?"
+          fsharp-access-control-regexp-noncapturing "*"
+          "(\\(|[A-Za-z0-9_'|]+|\\))\\(?:\\s-+[A-Za-z_]\\|\\s-*(\\)"))
 
 (def-fsharp-compiled-var fsharp-member-access-regexp
   "\\<\\(?:override\\|member\\|abstract\\)\\s-+"
@@ -115,20 +120,23 @@ with initial value INITVALUE and optional DOCSTRING."
 
 (def-fsharp-compiled-var fsharp-member-function-regexp
   (concat fsharp-member-access-regexp
-          "\\(?:\\(?:inline\\|rec\\)\\s-+\\)?\\(?:"
-          fsharp-valid-identifier-regexp
-          "\\.\\)?\\("
-          fsharp-valid-identifier-regexp
-          "\\)")
+          fsharp-inline-rec-regexp-noncapturing "?"
+          fsharp-access-control-regexp-noncapturing "*"
+          "\\(?:" fsharp-valid-identifier-regexp "\\.\\)?"
+          "\\(" fsharp-valid-identifier-regexp "\\)")
   "Captures the final identifier in a member function declaration.")
 
 (def-fsharp-compiled-var fsharp-overload-operator-regexp
   (concat fsharp-member-access-regexp
-          "\\(?:\\(?:inline\\|rec\\)\\s-+\\)?\\(([!%&*+-./<=>?@^|~]+)\\)")
+          fsharp-inline-rec-regexp-noncapturing "?"
+          fsharp-access-control-regexp-noncapturing "*"
+          "\\(([!%&*+-./<=>?@^|~]+)\\)")
   "Match operators when overloaded by a type/class.")
 
 (def-fsharp-compiled-var fsharp-constructor-regexp
-  "^\\s-*\\<\\(new\\) *(.*)[^=]*="
+  (concat "^\\s-*"
+          fsharp-access-control-regexp-noncapturing "*"
+          "\\<\\(new\\) *(.*)[^=]*=")
   "Matches the `new' keyword in a constructor")
 
 (def-fsharp-compiled-var fsharp-type-def-regexp

--- a/test/apps/FSharp.Compatibility/Format.fs.faceup
+++ b/test/apps/FSharp.Compatibility/Format.fs.faceup
@@ -849,7 +849,7 @@
   
 «m:/// »«x:Re-implementation of OCaml's Pervasives.output, since the one in the
 »«m:/// »«x:F# compatibility library doesn't have the right type signature.
-»«k:let» «k:private» «v:output» «v:oc» («v:buf» : «t:string») («v:pos» : «t:int») («v:len» : «t:int») =
+»«k:let» «k:private» «f:output» «v:oc» («v:buf» : «t:string») («v:pos» : «t:int») («v:len» : «t:int») =
     output_string oc (buf.Substring (pos, len))
 
 «k:let» «f:pp_set_formatter_out_channel» «v:state» «v:os» =


### PR DESCRIPTION
This enhances both coloring (`let private f x` now colors `f` as a function) and imenu support (`f` is listed, not `private`).