### PR TITLE
Stop matching [ as part of normal residue.

### DIFF
--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -485,7 +485,7 @@ If HOST is nil, check process on local system."
            (or (regexp ,fsharp-ac--ident)
                (regexp ,fsharp-ac--rawIdent))
            "."))
-         (group (zero-or-more (not (any ":.` ,(\t\r\n"))))
+         (group (zero-or-more (not (any "\[:.` ,(\t\r\n"))))
          string-end))
   "Regexp for a dotted ident with a standard residue.")
 


### PR DESCRIPTION
One of the regexp used to calculate the prefix while doing auto-completion is matching too many things.
This stops matching `[` as a part of what's being auto-completed.

Should fix #161 