### PR TITLE
Flycheck: Add predicate function (WIP)

### DIFF
--- a/flycheck-fsharp.el
+++ b/flycheck-fsharp.el
@@ -48,6 +48,7 @@ CALLBACK is the status callback passed by Flycheck."
   "A syntax checker for F# using FSharp.AutoComplete.
 See URL `https://github.com/fsharp/FsAutoComplete'."
   :start #'flycheck-fsharp-fsautocomplete-lint-start
+  :predicate (lambda () (fsharp-ac-can-make-request t))
   :modes '(fsharp-mode))
 
 (defvar flycheck-fsharp--error-callback-info nil)
@@ -63,6 +64,7 @@ CALLBACK is the status callback passed by Flycheck."
 See URL `https://github.com/fsharp/FsAutoComplete'."
   :start #'flycheck-fsharp-fsautocomplete-start
   :modes '(fsharp-mode)
+  :predicate (lambda () (fsharp-ac-can-make-request t))
   :next-checkers '((info . fsharp-fsautocomplete-lint)))
 
 (defun flycheck-fsharp-handle-lint (data)

--- a/flycheck-fsharp.el
+++ b/flycheck-fsharp.el
@@ -34,6 +34,9 @@
 
 (defvar flycheck-fsharp--lint-callback-info nil)
 
+(defun flycheck-fsharp--can-make-request-p ()
+  (fsharp-ac-can-make-request t))
+
 (defun flycheck-fsharp-fsautocomplete-lint-start (checker callback)
   "Start a F# syntax check with CHECKER.
 CALLBACK is the status callback passed by Flycheck."
@@ -48,7 +51,7 @@ CALLBACK is the status callback passed by Flycheck."
   "A syntax checker for F# using FSharp.AutoComplete.
 See URL `https://github.com/fsharp/FsAutoComplete'."
   :start #'flycheck-fsharp-fsautocomplete-lint-start
-  :predicate (lambda () (fsharp-ac-can-make-request t))
+  :predicate #'flycheck-fsharp--can-make-request-p
   :modes '(fsharp-mode))
 
 (defvar flycheck-fsharp--error-callback-info nil)
@@ -64,7 +67,7 @@ CALLBACK is the status callback passed by Flycheck."
 See URL `https://github.com/fsharp/FsAutoComplete'."
   :start #'flycheck-fsharp-fsautocomplete-start
   :modes '(fsharp-mode)
-  :predicate (lambda () (fsharp-ac-can-make-request t))
+  :predicate #'flycheck-fsharp--can-make-request-p
   :next-checkers '((info . fsharp-fsautocomplete-lint)))
 
 (defun flycheck-fsharp-handle-lint (data)

--- a/test/test-common.el
+++ b/test/test-common.el
@@ -29,6 +29,7 @@
 (defmacro stubbing-process-functions (&rest body)
   `(noflet ((process-live-p (p) t)
             (fsharp-ac--process-live-p (host) t)
+	    (flycheck-fsharp--can-make-request-p () t)
             (start-process (&rest args))
             (set-process-filter (&rest args))
             (set-process-query-on-exit-flag (&rest args))


### PR DESCRIPTION
Prevents calling checker when FSharp.AutoComplete process is not
ready to handle requests. Refs #167