### PR TITLE
Scoop

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  FSACVERSION: 0.18.0
+  FSACVERSION: 0.34.0
   FSharpBinding_BlockingTimeout: 1000
   FSharpBinding_MaxTimeout: 10000
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,13 @@ matrix:
 install:
   - ps: Start-FileDownload "https://github.com/fsharp/FSharp.AutoComplete/releases/download/$env:FSACVERSION/fsautocomplete.zip"
   - ps: 7z x fsautocomplete.zip -oemacs-fsharp-mode\bin | select-string -notmatch "ing  "
-  - cinst emacs
+  - ps: iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+  - ps: scoop install coreutils
+  - ps: scoop install make
+  - ps: scoop install grep
+  - ps: scoop install unzip
+  - ps: scoop bucket add extras
+  - ps: scoop install emacs
 build_script:
   - cmd: .\.appveyor\test.bat
 test: off


### PR DESCRIPTION
The Emacs package on Chocolatey is [broken](https://ci.appveyor.com/project/tpetricek/emacs-fsharp-mode/build/1.0.351) (Emacs download link changed) and outdated since 5 years: https://chocolatey.org/packages/Emacs


