### PR TITLE
Fix a small bug in font locking for active patterns

### DIFF
--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -293,7 +293,8 @@ with initial value INITVALUE and optional DOCSTRING."
       (,fsharp-pattern-function-regexp 1 font-lock-function-name-face)
       ;; Active records
       ("(|" (0 'fsharp-ui-operator-face)
-       ("\\([A-Za-z'_]+\\)\\(|)\\)" nil nil
+       ("\\([A-Za-z'_]+\\)\\(|)?\\)"
+        nil nil
         (1 font-lock-function-name-face)
         (2 'fsharp-ui-operator-face)))
       (,fsharp-operator-pipe-regexp . 'fsharp-ui-operator-face)


### PR DESCRIPTION
This commit fixes a bug in which only the final name in a multi-symbol active
record would be font locked. The trouble is that the regexp requires the closing
banana clip |) as part of the pattern; the final paren should be _optional_.
Thus, the only meaningful change is adding a ? inside the regexp. A newline is
introduced to make the whole thing slightly more readable.