### PR TITLE
Fix attribute locking, improve imenu

### DIFF
--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -288,7 +288,7 @@ with initial value INITVALUE and optional DOCSTRING."
       ;; attributes
       (,fsharp-attributes-regexp
        (1 font-lock-preprocessor-face)
-       (2 font-lock-string-face)
+       (2 font-lock-string-face nil t)
        (3 font-lock-preprocessor-face))
       ;; ;; type defines
       (,fsharp-type-def-regexp 1 font-lock-type-face)

--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -153,9 +153,8 @@ with initial value INITVALUE and optional DOCSTRING."
           "\\([A-Za-z_][A-Za-z0-9_']*\\)\\s-*:\\s-*\\([A-Za-z_][A-Za-z0-9_'<> \t]*\\)"))
 
 (def-fsharp-compiled-var fsharp-attributes-regexp
-  "\\[<[A-Za-z0-9_]+>\\]"
-  "Match attributes like [<EntryPoint>]")
-
+  "\\(\\[<[A-Za-z0-9_]+(?\\)\\(\".*\"\\)?\\()?>\\]\\)"
+  "Match attributes like [<EntryPoint>]; separately groups contained strings in attributes like [<Attribute(\"property\")>]")
 
 ;; F# makes extensive use of operators, many of which have some kind of
 ;; structural significance.
@@ -286,7 +285,10 @@ with initial value INITVALUE and optional DOCSTRING."
        (1 font-lock-comment-face)
        (2 font-lock-keyword-face))
       ;; attributes
-      (,fsharp-attributes-regexp . font-lock-preprocessor-face)
+      (,fsharp-attributes-regexp
+       (1 font-lock-preprocessor-face)
+       (2 font-lock-string-face)
+       (3 font-lock-preprocessor-face))
       ;; ;; type defines
       (,fsharp-type-def-regexp 1 font-lock-type-face)
       (,fsharp-function-def-regexp 1 font-lock-function-name-face)

--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -179,14 +179,15 @@ with initial value INITVALUE and optional DOCSTRING."
   "Match literal | in contexts like match and type declarations.")
 
 (defvar fsharp-imenu-generic-expression
-  `((nil ,(concat "^\\s-*" fsharp-function-def-regexp) 1)
-    (nil ,(concat "^\\s-*" fsharp-pattern-function-regexp) 1)
-    (nil ,(concat "^\\s-*" fsharp-active-pattern-regexp) 1)
-    (nil ,(concat "^\\s-*" fsharp-member-function-regexp) 1)
-    (nil ,(concat "^\\s-*" fsharp-overload-operator-regexp) 1)
-    (nil ,fsharp-constructor-regexp 1)
-    (nil ,fsharp-type-def-regexp 1)
-    )
+  `((nil                 ,(concat "^\\s-*" fsharp-function-def-regexp) 1)
+    (nil                 ,(concat "^\\s-*" fsharp-pattern-function-regexp) 1)
+    ("Active Pattern"    ,(concat "^\\s-*" fsharp-active-pattern-regexp) 1)
+    ("Member"            ,(concat "^\\s-*" fsharp-member-function-regexp) 1)
+    ("Overload Operator" ,(concat "^\\s-*" fsharp-overload-operator-regexp) 1)
+    ("Constructor"       ,fsharp-constructor-regexp 1)
+    ("Type"              ,fsharp-type-def-regexp 1)
+    ("Module"            ,(concat "\\s-*module " fsharp-var-or-arg-regexp) 1))
+
   "Provide iMenu support through font-locking regexen.")
 
 (defun fsharp-imenu-load-index ()

--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -153,7 +153,7 @@ with initial value INITVALUE and optional DOCSTRING."
           "\\([A-Za-z_][A-Za-z0-9_']*\\)\\s-*:\\s-*\\([A-Za-z_][A-Za-z0-9_'<> \t]*\\)"))
 
 (def-fsharp-compiled-var fsharp-attributes-regexp
-  "\\(\\[<[A-Za-z0-9_]+(?\\)\\(\".*\"\\)?\\()?>\\]\\)"
+  "\\(\\[<[A-Za-z0-9_]+[( ]?\\)\\(\".*\"\\)?\\()?>\\]\\)"
   "Match attributes like [<EntryPoint>]; separately groups contained strings in attributes like [<Attribute(\"property\")>]")
 
 ;; F# makes extensive use of operators, many of which have some kind of


### PR DESCRIPTION
This PR does two things:

1. Updates `imenu` generation so that elements in the `imenu` display aren't all just labelled "Function", while adding support for jumping to Module declarations.
2. Fixes font locking for parameterized attributes. 

Before, locking an attribute like Argu's `[<AltCommandLine("-d")>]` would fail, as the  current locking cannot recognize either the internal parens or the internal string. This PR fixes that, locking the string as such, and making sure everything else is correctly, er, attributed. 

I do feel... a little sheepish about putting both things on the same branch. Please let me know if two PRs are preferred, or if these changes are minor/cosmetic enough that it's no bother. 