### PR TITLE
Add the option to build and install with different versions of fsac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ ac_version = 0.34.0
 ac_archive = $(ac_name)-$(ac_version).zip
 ac_url     = https://github.com/fsharp/FsAutoComplete/releases/download/$(ac_version)/$(ac_name).zip
 
+# Autocomplete commit or branch to build from if not using the binary distribution.
+ac_commit = master
+ac_src_url = https://github.com/fsharp/FsAutoComplete/archive/$(ac_commit).zip
+ac_src_archive = $(ac_name)-$(ac_commit).zip
+ac_from_src = no
+
+ac_build_dir = $(tmp_d)/FsAutoComplete-$(ac_commit)
+
 # Installation paths.
 dest_root = $(HOME)/.emacs.d/fsharp-mode/
 dest_bin  = $(HOME)/.emacs.d/fsharp-mode/bin/
@@ -36,11 +44,20 @@ dest_bin  = $(HOME)/.emacs.d/fsharp-mode/bin/
 # ----------------------------------------------------------------------------
 
 .PHONY : test unit-test integration-test packages clean-elc install byte-compile check-compile run update-version release faceup
+.ONESHELL : $(ac_archive)
 
 # Building
 
 $(ac_archive): | $(bin_d)
+ifeq ($(ac_from_src), no)
 	curl -L "$(ac_url)" -o "$(ac_archive)"
+else
+	curl -L "$(ac_src_url)" -o "$(ac_src_archive)"
+	unzip "$(ac_src_archive)" -d "$(tmp_d)"
+	$(ac_build_dir)/build.sh releasearchive
+	mv $(ac_build_dir)/bin/pkgs/$(ac_name).zip $(ac_archive)
+endif
+
 
 $(ac_exe) : $(bin_d) $(ac_archive)
 	unzip "$(ac_archive)" -d "$(bin_d)"

--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ There are some issues with the `pos-tip` library used to display the documentati
 
 If you installed by cloning the git repository and you are having problems, please sanity check by running `make test-all` in the `emacs` folder.
 
+### Using a different version of FsAutoComplete
+
+Installing with `make install ac_from_src=yes` will build FsAutoComplete from their lastest master commit instead of using their current binary distribution. Build from a specific commit by passing `ac_commit=$COMMIT_HASH`.
+
 ## Contributing
 
 This project is maintained by the


### PR DESCRIPTION
This should be helpful for people running into #183 and related issues, and seems like a useful thing to be able to do in general. 