### PR TITLE
[WIP] Support .NET Core as the FSAC runtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.elc
 bin
+bin_netcore
 tmp
 
 # Useful for doing releases

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -44,15 +44,18 @@
 ;;; User-configurable variables
 
 (defvar fsharp-ac-executable "fsautocomplete.exe")
+(defvar fsharp-ac-dotnetcore-executable "fsautocomplete.dll")
+
+(defun fsharp-ac-find-executable (bin-dir exec)
+    (or (executable-find exec)
+        (concat (file-name-directory (or load-file-name buffer-file-name))
+                bin-dir exec)))
 
 (defvar fsharp-ac-complete-command
-  (let ((exe (or (executable-find fsharp-ac-executable)
-                 (concat (file-name-directory (or load-file-name buffer-file-name))
-                         "bin/" fsharp-ac-executable))))
     (case (fsharp-ac-runtime)
-      (dotnetcore (list "dotnet" exe))
-      (mono (list "mono" exe))
-      (dotnet (list exe))))
+      (dotnetcore (list "dotnet" (fsharp-ac-find-executable "bin_netcore/" fsharp-ac-dotnetcore-executable)))
+      (mono (list "mono" (fsharp-ac-find-executable "bin/" fsharp-ac-executable)))
+      (dotnet (list (fsharp-ac-find-executable "bin/" fsharp-ac-executable))))
   "Command to start the completion process.
 If using Tramp this command must be also valid on remote the Host.")
 
@@ -343,7 +346,7 @@ If HOST is nil, check process on local system."
 		   (concat (file-remote-p default-directory) (car (last fsharp-ac-complete-command)))
 		 (car (last fsharp-ac-complete-command))))
 	 (process-environment
-	  (if (not (eq 'mono fsharp-ac-using-mono))
+	  (if (not (eq 'mono (fsharp-ac-runtime)))
 	      process-environment
 	    ;; workaround for Mono = 4.2.1 thread pool bug
 	    ;; https://bugzilla.xamarin.com/show_bug.cgi?id=37288

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -52,12 +52,16 @@
                 bin-dir exec)))
 
 (defvar fsharp-ac-complete-command
+  nil
+  "Command to start the completion process.
+If using Tramp this command must be also valid on remote the Host.")
+
+(setq fsharp-ac-complete-command
     (case (fsharp-ac-runtime)
       (dotnetcore (list "dotnet" (fsharp-ac-find-executable "bin_netcore/" fsharp-ac-dotnetcore-executable)))
       (mono (list "mono" (fsharp-ac-find-executable "bin/" fsharp-ac-executable)))
-      (dotnet (list (fsharp-ac-find-executable "bin/" fsharp-ac-executable))))
-  "Command to start the completion process.
-If using Tramp this command must be also valid on remote the Host.")
+      (dotnet (list (fsharp-ac-find-executable "bin/" fsharp-ac-executable)))))
+
 
 (defvar fsharp-ac-use-popup t
   "Display tooltips using a popup at point.

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -344,7 +344,7 @@ If HOST is nil, check process on local system."
 (defun fsharp-ac--configure-proc ()
   (let* ((fsac (if (tramp-tramp-file-p default-directory)
 		   (concat (file-remote-p default-directory) (car (last (fsharp-ac-complete-command))))
-		 (car (last fsharp-ac-complete-command))))
+		 (car (last (fsharp-ac-complete-command)))))
 	 (process-environment
 	  (if (not (eq 'mono fsharp-ac-runtime))
 	      process-environment

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -51,16 +51,12 @@
         (concat (file-name-directory (or load-file-name buffer-file-name))
                 bin-dir exec)))
 
-(defvar fsharp-ac-complete-command
-  nil
-  "Command to start the completion process.
-If using Tramp this command must be also valid on remote the Host.")
-
-(setq fsharp-ac-complete-command
-    (case (fsharp-ac-runtime)
+(defun fsharp-ac-complete-command ()
+    (case fsharp-ac-runtime
       (dotnetcore (list "dotnet" (fsharp-ac-find-executable "bin_netcore/" fsharp-ac-dotnetcore-executable)))
       (mono (list "mono" (fsharp-ac-find-executable "bin/" fsharp-ac-executable)))
       (dotnet (list (fsharp-ac-find-executable "bin/" fsharp-ac-executable)))))
+
 
 
 (defvar fsharp-ac-use-popup t
@@ -347,10 +343,10 @@ If HOST is nil, check process on local system."
 
 (defun fsharp-ac--configure-proc ()
   (let* ((fsac (if (tramp-tramp-file-p default-directory)
-		   (concat (file-remote-p default-directory) (car (last fsharp-ac-complete-command)))
+		   (concat (file-remote-p default-directory) (car (last (fsharp-ac-complete-command))))
 		 (car (last fsharp-ac-complete-command))))
 	 (process-environment
-	  (if (not (eq 'mono (fsharp-ac-runtime)))
+	  (if (not (eq 'mono fsharp-ac-runtime))
 	      process-environment
 	    ;; workaround for Mono = 4.2.1 thread pool bug
 	    ;; https://bugzilla.xamarin.com/show_bug.cgi?id=37288
@@ -364,7 +360,7 @@ If HOST is nil, check process on local system."
 	(let ((proc (apply 'start-file-process
 			   fsharp-ac--completion-procname
 			   (get-buffer-create (generate-new-buffer-name " *fsharp-complete*"))
-			   fsharp-ac-complete-command)))
+			   (fsharp-ac-complete-command))))
 	  (sleep-for 0.1)
 	  (if (process-live-p proc)
 	      (progn
@@ -375,7 +371,7 @@ If HOST is nil, check process on local system."
 		(with-current-buffer (process-buffer proc)
 		  (delete-region (point-min) (point-max)))
 		proc)
-	    (error "Failed to launch: '%s'" (s-join " " fsharp-ac-complete-command))
+	    (error "Failed to launch: '%s'" (s-join " " (fsharp-ac-complete-command)))
 	    nil))
       (error "%s not found" fsac))))
 

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -49,9 +49,10 @@
   (let ((exe (or (executable-find fsharp-ac-executable)
                  (concat (file-name-directory (or load-file-name buffer-file-name))
                          "bin/" fsharp-ac-executable))))
-    (if fsharp-ac-using-mono
-        (list "mono" exe)
-      (list exe)))
+    (case (fsharp-ac-runtime)
+      (dotnetcore (list "dotnet" exe))
+      (mono (list "mono" exe))
+      (dotnet (list exe))))
   "Command to start the completion process.
 If using Tramp this command must be also valid on remote the Host.")
 
@@ -342,7 +343,7 @@ If HOST is nil, check process on local system."
 		   (concat (file-remote-p default-directory) (car (last fsharp-ac-complete-command)))
 		 (car (last fsharp-ac-complete-command))))
 	 (process-environment
-	  (if (null fsharp-ac-using-mono)
+	  (if (not (eq 'mono fsharp-ac-using-mono))
 	      process-environment
 	    ;; workaround for Mono = 4.2.1 thread pool bug
 	    ;; https://bugzilla.xamarin.com/show_bug.cgi?id=37288

--- a/fsharp-mode-completion.el
+++ b/fsharp-mode-completion.el
@@ -50,12 +50,14 @@
     (or (executable-find exec)
         (concat (file-name-directory (or load-file-name buffer-file-name))
                 bin-dir exec)))
+(defvar fsharp-ac--full-executable (fsharp-ac-find-executable "bin/" fsharp-ac-executable))
+(defvar fsharp-ac--full-dotnetcore-executable (fsharp-ac-find-executable "bin_netcore/" fsharp-ac-dotnetcore-executable))
 
 (defun fsharp-ac-complete-command ()
     (case fsharp-ac-runtime
-      (dotnetcore (list "dotnet" (fsharp-ac-find-executable "bin_netcore/" fsharp-ac-dotnetcore-executable)))
-      (mono (list "mono" (fsharp-ac-find-executable "bin/" fsharp-ac-executable)))
-      (dotnet (list (fsharp-ac-find-executable "bin/" fsharp-ac-executable)))))
+      (dotnetcore (list "dotnet" fsharp-ac--full-dotnetcore-executable))
+      (mono (list "mono" fsharp-ac--full-executable))
+      (dotnet (list fsharp-ac--full-executable))))
 
 
 

--- a/fsharp-mode-util.el
+++ b/fsharp-mode-util.el
@@ -27,7 +27,7 @@
 (require 'dash)
 
 
-(defvar fsharp-ac-runtime ()
+(defvar fsharp-ac-runtime
   "The .NET runtime for FSAutoComplete.
 Possible options are dotnet, mono, and dotnetcore"
     (case system-type

--- a/fsharp-mode-util.el
+++ b/fsharp-mode-util.el
@@ -28,11 +28,12 @@
 
 
 (defvar fsharp-ac-runtime
-  "The .NET runtime for FSAutoComplete.
-Possible options are dotnet, mono, and dotnetcore"
     (case system-type
       ((windows-nt cygwin msdos) 'dotnet)
-      (otherwise 'mono)))
+      (otherwise 'mono))
+  "The .NET runtime for FSAutoComplete.
+Possible options are dotnet, mono, and dotnetcore"
+    )
 
 (defun fsharp-mode--program-files-x86 ()
   (file-name-as-directory

--- a/fsharp-mode-util.el
+++ b/fsharp-mode-util.el
@@ -25,6 +25,7 @@
 
 (with-no-warnings (require 'cl))
 (require 'dash)
+(require 'subr-x)
 
 
 (defvar fsharp-ac-runtime

--- a/fsharp-mode-util.el
+++ b/fsharp-mode-util.el
@@ -44,6 +44,7 @@ Possible options are dotnet, mono, and dotnetcore"
                            "C:\\Program Files (x86)")))))
 
 (defun fsharp-mode--program-files-dotnetcore ()
+  "Get the appropriate program files folder based off of the dotnet sdk version of the project."
   (let* ((currentSdk (string-trim (shell-command-to-string "dotnet --version")))
          ;; dotnet --list-sdks outputs a list of sdk versions, followed by the sdk path surrounded in square brackets
          (sdkPaths (-map #'fsharp-mode--parse-dotnet-list-sdk
@@ -53,11 +54,11 @@ Possible options are dotnet, mono, and dotnetcore"
     (concat (file-name-as-directory sdkPath) "FSharp/")))
 
 (defun fsharp-mode--parse-dotnet-list-sdk (sdk)
+  "Parse a line SDK of dotnet --list-sdks into a pair of version and path."
   (let* ((splitSdk (split-string sdk))
          (version (-first-item splitSdk))
          (path (-second-item splitSdk)))
     (cons version path)))
-    ;; (-second-item (split-string sdkPath))))
 
 (defun fsharp-mode--vs2017-msbuild-find (exe)
   "Return EXE absolute path for Visual Studio 2017, if existent, else nil."
@@ -81,6 +82,7 @@ Possible options are dotnet, mono, and dotnetcore"
     (mono (executable-find exe))))
 
 (defun fsharp-mode--executable-find (exe)
+  "Find the executable EXE based off fs-ac-runtime."
   (case fsharp-ac-runtime
     (dotnetcore (let* ((exec-path (append (list (fsharp-mode--program-files-dotnetcore)) exec-path))
                        (dotnet-exec (executable-find "dotnet"))

--- a/fsharp-mode-util.el
+++ b/fsharp-mode-util.el
@@ -26,22 +26,13 @@
 (with-no-warnings (require 'cl))
 (require 'dash)
 
-(defvar fsharp-ac-use-dotnetcore
-  t
-  "Use .NET Core as the runtime for FSAutoComplete.
 
-If set to nil, fall back to either .NET or mono runtimes (depending on the system).")
-
-(defun fsharp-ac-runtime ()
+(defvar fsharp-ac-runtime ()
   "The .NET runtime for FSAutoComplete.
-If fsharp-ac-use-dotnetcore is set to t, this variable is set to dotnetcore
-Defaults to nil for Microsoft platforms (including Cygwin), t
-for all *nix."
-  (if fsharp-ac-use-dotnetcore
-      'dotnetcore
+Possible options are dotnet, mono, and dotnetcore"
     (case system-type
       ((windows-nt cygwin msdos) 'dotnet)
-      (otherwise 'mono))))
+      (otherwise 'mono)))
 
 (defun fsharp-mode--program-files-x86 ()
   (file-name-as-directory
@@ -78,7 +69,7 @@ for all *nix."
 
 (defun fsharp-mode--msbuild-find (exe)
   "Find the build tool EXE based off fs-ac-runtime."
-  (case (fsharp-ac-runtime)
+  (case fsharp-ac-runtime
     (dotnetcore (executable-find exe))
     (dotnet (let* ((searchdirs (--map (concat (fsharp-mode--program-files-x86)
                                       "MSBuild/" it "/Bin")
@@ -88,7 +79,7 @@ for all *nix."
     (mono (executable-find exe))))
 
 (defun fsharp-mode--executable-find (exe)
-  (case (fsharp-ac-runtime)
+  (case fsharp-ac-runtime
     (dotnetcore (let* ((exec-path (append (list (fsharp-mode--program-files-dotnetcore)) exec-path))
                        (dotnet-exec (executable-find "dotnet"))
                       (executable (locate-file exe exec-path)))

--- a/fsharp-mode-util.el
+++ b/fsharp-mode-util.el
@@ -76,7 +76,7 @@ for all *nix."
 	      '("Enterprise/" "Professional/" "Community/" "BuildTools/"))
        (--first (file-executable-p it))))
 
-(defun fsharp-mode--build-find (exe)
+(defun fsharp-mode--msbuild-find (exe)
   "Find the build tool EXE based off fs-ac-runtime."
   (case (fsharp-ac-runtime)
     (dotnetcore (executable-find exe))

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -28,6 +28,7 @@
 
 ;;; Code:
 
+(with-no-warnings (require 'cl))
 (require 'fsharp-mode-completion)
 (require 'flycheck-fsharp)
 (require 'fsharp-doc)
@@ -383,9 +384,10 @@ passed to `mono'."
          (default (if (and outputfile
                            (s-equals? "exe"
                                       (downcase (file-name-extension outputfile))))
-                      (if fsharp-ac-using-mono
-                          (s-concat "mono " outputfile)
-                        outputfile)
+                      (case (fsharp-ac-runtime)
+                        (dotnetcore (s-concat "dotnet " outputfile))
+                        (mono (s-concat "mono" outputfile))
+                        (dotnet outputfile))
                     ""))
          (cmd (read-from-minibuffer "Run: "
                                     default

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -384,7 +384,7 @@ passed to `mono'."
          (default (if (and outputfile
                            (s-equals? "exe"
                                       (downcase (file-name-extension outputfile))))
-                      (case (fsharp-ac-runtime)
+                      (case fsharp-ac-runtime
                         (dotnetcore (s-concat "dotnet " outputfile))
                         (mono (s-concat "mono" outputfile))
                         (dotnet outputfile))

--- a/inf-fsharp-mode.el
+++ b/inf-fsharp-mode.el
@@ -37,9 +37,10 @@
   "*If true, display the inferior fsharp buffer when evaluating expressions.")
 
 (defvar inferior-fsharp-program
-  (if fsharp-ac-using-mono
-      "fsharpi --readline-"
-    (concat "\"" (fsharp-mode--executable-find "fsi.exe") "\" --fsi-server-input-codepage:65001"))
+  (case (fsharp-ac-runtime)
+    (dotnetcore (fsharp-mode--executable-find "fsi.exe"))
+    (mono "fsharpi --readline-")
+    (dotnet (concat "\"" (fsharp-mode--executable-find "fsi.exe") "\" --fsi-server-input-codepage:65001")))
   "*Program name for invoking an inferior fsharp from Emacs.")
 
 ;; End of User modifiable variables

--- a/inf-fsharp-mode.el
+++ b/inf-fsharp-mode.el
@@ -37,7 +37,7 @@
   "*If true, display the inferior fsharp buffer when evaluating expressions.")
 
 (defvar inferior-fsharp-program
-  (case (fsharp-ac-runtime)
+  (case fsharp-ac-runtime
     (dotnetcore (fsharp-mode--executable-find "fsi.exe"))
     (mono "fsharpi --readline-")
     (dotnet (concat "\"" (fsharp-mode--executable-find "fsi.exe") "\" --fsi-server-input-codepage:65001")))


### PR DESCRIPTION
This is very WIP, but it aims to support .NET Core as a runtime for FSAC. This would remove `mono` as a dependency for those that choose to.