### PR TITLE
Set default build command to msbuild if it is found

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -49,7 +49,7 @@
   "The program used to compile F# source files.")
 
 (defvar fsharp-build-command
-  (-any #'fsharp-mode--msbuild-find '("xbuild" "msbuild"))
+  (-any #'fsharp-mode--msbuild-find '("msbuild" "xbuild"))
   "The command used to build F# projects and solutions.")
 
 ;;; ----------------------------------------------------------------------------


### PR DESCRIPTION
Newer versions of Mono have deprecated xbuild and encourage usage of the msbuild
command that ship with Mono instead. Picking xbuild as the default causes issues
with modern VS project files, which it does not understand. It should be
reasonably safe to prefer using msbuild over xbuild on any platform where
msbuild is found.