### PR TITLE
Add setting for conservative indent on first line after bracket

### DIFF
--- a/fsharp-mode-indent.el
+++ b/fsharp-mode-indent.el
@@ -53,6 +53,14 @@ statement are given this extra offset."
   :type 'integer
   :group 'fsharp)
 
+(defcustom fsharp-conservative-indentation-after-bracket nil
+  "Indent by fsharp-continuation-offset also after an opening bracket.
+The default indentation depth on a new line after an opening
+bracket is one column further from the opening bracket. Indenting much less is
+allowed, because brackets reset the current offside column."
+  :type 'boolean
+  :group 'fsharp)
+
 (defcustom fsharp-smart-indentation t
   "*Should `fsharp-mode' try to automagically set some indentation variables?
 When this variable is non-nil, two things happen when a buffer is set
@@ -484,7 +492,8 @@ dedenting."
                 (goto-char (1+ open-bracket-pos)) ; just beyond bracket
                 ;; is the first list item on the same line?
                 (skip-chars-forward " \t")
-                (if (null (memq (following-char) '(?\n ?# ?\\)))
+                (if (and (null (memq (following-char) '(?\n ?# ?\\)))
+                         (not fsharp-conservative-indentation-after-bracket))
                                         ; yes, so line up with it
                     (current-column)
                   ;; first list item on another line, or doesn't exist yet


### PR DESCRIPTION
If I press return when point is at the square in the following line of code:

```
let SigninButton = FunctionComponent.Of (fun (props : UntypedProps) ->▊
)
```

fsharp-mode helpfully indents for alignment:

```
let SigninButton = FunctionComponent.Of (fun (props : UntypedProps) ->
·········································▊
)
```

I prefer a less aligning indentation style, where I indent only by the same
amount any time it is legally possible to do so. In this case, what I wanted was
the more conservative

```
let SigninButton = FunctionComponent.Of (fun (props : UntypedProps) ->
····▊
)
```

This commit adds a customizeable variable that makes fsharp-mode indent in this
more conservative way instead.