### PR TITLE
Add curly brace as token that should be outdented

### DIFF
--- a/fsharp-mode-indent.el
+++ b/fsharp-mode-indent.el
@@ -156,7 +156,8 @@ as indentation hints, unless the comment character is in column zero."
                              "finally"
                              "end"
                              "done"
-                             "elif")
+                             "elif"
+                             "}")
                            "\\|")
           "\\)")
   "Regular expression matching statements to be dedented one level.")


### PR DESCRIPTION
There are three examples I know of what this does:

Before this patch, we see the following three indentations happening:

```
type X =
····{
········field : WithType
········}
```

```
let foo =
····async {
········field : WithType
········}
```

```
let foo = seq {
········field : WithType
········}
```

Whereas with this patch, we instead get

```
type X =
····{
········field : WithType
····}
```

```
let foo =
····async {
········field : WithType
····}
```

```
let foo = seq {
····field : WithType
}
```

This, I believe, fixes #203.