### PR TITLE
Lsp part2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - sudo dpkg -i packages-microsoft-prod.deb
   - sudo apt-get update
   - sudo apt-get install apt-transport-https
+  - sudo apt-get update
   - sudo apt-get install dotnet-sdk-2.1
   - export PATH="$HOME/bin:$PATH"
   - export EMACS=$EMACS_VERSION

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,11 @@ build: elpa version
 version:
 	$(EMACS) --version
 
-test/Test1/project.assets.json:
+test/Test1/restored:
 	dotnet restore test/Test1
+	touch test/Test1/restored
 
-test: version build test/eglot-tests.el test/Test1/project.assets.json
+test: version build test/eglot-tests.el test/Test1/restored
 	$(CASK) exec buttercup -L . -L ./test --traceback full
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test/Test1/project.assets.json:
 	dotnet restore test/Test1
 
 test: version build test/eglot-tests.el test/Test1/project.assets.json
-	$(CASK) exec buttercup -L . -L ./test
+	$(CASK) exec buttercup -L . -L ./test --traceback full
 
 clean:
 	rm -f .depend elpa-$(EMACS) $(OBJECTS) $(PKG)-autoloads.el

--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -107,6 +107,18 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
   "Passes through required FsAutoComplete initialization options."
   '(:automaticWorkspaceInit t))
 
+;; FIXME: this should be fixed in FsAutocomplete
+(cl-defmethod xref-backend-definitions :around ((type symbol) _identifier)
+  "FsAutoComplete breaks spec and and returns error instead of empty list."
+  (if (eq major-mode 'fsharp-mode)
+      (condition-case err
+	  (cl-call-next-method)
+	(jsonrpc-error
+	 (when (equal (cadddr err) '(jsonrpc-error-message . "Could not find declaration"))
+	   nil)))
+    (when (cl-next-method-p)
+      (cl-call-next-method))))
+
 (add-to-list 'eglot-server-programs `(fsharp-mode . eglot-fsharp))
 
 (provide 'eglot-fsharp)

--- a/test/Test1/Error.fs
+++ b/test/Test1/Error.fs
@@ -1,0 +1,4 @@
+module Error
+
+let x = nonexisting()
+

--- a/test/Test1/Test1.fsproj
+++ b/test/Test1/Test1.fsproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Error.fs" />
     <Compile Include="FileTwo.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/test/Test1/Test1.fsproj
+++ b/test/Test1/Test1.fsproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Program.fs" />
     <Compile Include="FileTwo.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
 
 </Project>

--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -49,7 +49,17 @@
             (&key _id method &allow-other-keys)
           (string= method "textDocument/publishDiagnostics")))
       (completion-at-point)
-      (expect (looking-back "X\\.func") :to-be t))))
+      (expect (looking-back "X\\.func") :to-be t)))
+  (it "doesn't throw error when definition does not exist"
+      (with-current-buffer (eglot--find-file-noselect "test/Test1/Program.fs")
+	(goto-char 253)
+	(expect (current-word) :to-equal "printfn") ;sanity check
+	(expect
+	 (condition-case err
+	     (call-interactively #'xref-find-definitions)
+	   (user-error
+	    (cadr err)))
+	 :to-equal "No definitions found for: LSP identifier at point."))))
 
 (provide 'integration-tests)
 ;;; integration-tests.el ends here

--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -32,6 +32,19 @@
   (it "Can be installed"
     (eglot-fsharp--maybe-install)
     (expect (file-exists-p  (eglot-fsharp--path-to-server)) :to-be t))
+  (it "shows flymake errors"
+    (with-current-buffer (eglot--find-file-noselect "test/Test1/Error.fs")
+      (eglot--tests-connect 10)
+      (search-forward "nonexisting")
+      (flymake-mode t)
+      (flymake-start)
+      (goto-char (point-min))
+      (eglot--sniffing (:server-notifications s-notifs)
+        (eglot--wait-for (s-notifs 10)
+            (&key _id method &allow-other-keys)
+          (string= method "textDocument/publishDiagnostics")))
+      (flymake-goto-next-error 1 '() t)
+      (expect (face-at-point) :to-be 'flymake-error )))
   (it "is enabled on F# Files"
     (with-current-buffer (eglot--find-file-noselect "test/Test1/FileTwo.fs")
       (eglot--tests-connect 30)

--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -30,7 +30,7 @@
 
 (defun eglot-fsharp--sniff-diagnostics ()
   (eglot--sniffing (:server-notifications s-notifs)
-    (eglot--wait-for (s-notifs 10)
+    (eglot--wait-for (s-notifs 20)
 	(&key _id method &allow-other-keys)
       (string= method "textDocument/publishDiagnostics"))))
 

--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -59,7 +59,13 @@
 	     (call-interactively #'xref-find-definitions)
 	   (user-error
 	    (cadr err)))
-	 :to-equal "No definitions found for: LSP identifier at point."))))
+	 :to-equal "No definitions found for: LSP identifier at point.")))
+  (it "finds definitions in other files of Project"
+      (with-current-buffer (eglot--find-file-noselect "test/Test1/Program.fs")
+	(goto-char 150)
+	(expect (current-word) :to-equal "NewObjectType") ;sanity check
+	(call-interactively #'xref-find-definitions)
+	(expect (file-name-nondirectory (buffer-file-name)) :to-equal "FileTwo.fs"))))
 
 (provide 'integration-tests)
 ;;; integration-tests.el ends here


### PR DESCRIPTION
Add (missing) integration tests (completion, jump-to-definition, flymake) from previous PR [Move to LSP (WIP)](https://github.com/fsharp/emacs-fsharp-mode/pull/210)

Also adds a eglot-workaround  `fsautocomplete-lsp` non-standard behaviour: [xref: Handle missing definitions gracfully …
](https://github.com/fsharp/emacs-fsharp-mode/commit/5e54c15e7c52dd8f7a3ec1ef8f9f34ff98193b83)