### PR TITLE
Avoid PR builds when downloading FsAutoComplete

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -66,7 +66,7 @@
 (defun eglot-fsharp--maybe-install ()
   "Downloads F# compiler service, and install in `eglot-fsharp-server-install-dir'."
   (make-directory (file-name-directory (eglot-fsharp--path-to-server)) t)
-  (let* ((url (format "https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete%szip?branch=master"
+  (let* ((url (format "https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete%szip?branch=master&pr=false"
 		      (if (eq eglot-fsharp-server-runtime 'net-core)
 			  ".netcore."
 			".")))


### PR DESCRIPTION
Without this flag the downloaded FsAutoComplete will be from a PR branch targetted to master, if that happens to be the latest successful build.

e.g. right now without this change it will download this build: https://ci.appveyor.com/project/fsautocomplete/fsautocomplete/builds/30225027