### PR TITLE
Execute .NET framework binary directly when running on Windows

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -95,10 +95,10 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
     (eglot-fsharp--maybe-install))
   (when (file-exists-p (eglot-fsharp--path-to-server))
     (cons 'eglot-fsautocomplete
-	  `(,(if (eq eglot-fsharp-server-runtime 'net-core)
-		 "dotnet"
-	       ;; FIXME: Windows
-	       "mono") ,(eglot-fsharp--path-to-server) "--background-service-enabled"))))
+	  `(,(cond ((eq eglot-fsharp-server-runtime 'net-core) "dotnet")
+               ((eq window-system 'w32) "")
+               ("mono"))
+        ,(eglot-fsharp--path-to-server) "--background-service-enabled"))))
 
 
 (defclass eglot-fsautocomplete (eglot-lsp-server) ()


### PR DESCRIPTION
Hi,

I am using this for F# development on Windows where I am living with a few restrictions and it may be useful for others, too. I have not tested this with different setups.

Kind regards, Florian