### PR TITLE
Installing of FsAutoComplete from github instead of appveyor.

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -66,10 +66,11 @@
 (defun eglot-fsharp--maybe-install ()
   "Downloads F# compiler service, and install in `eglot-fsharp-server-install-dir'."
   (make-directory (file-name-directory (eglot-fsharp--path-to-server)) t)
-  (let* ((url (format "https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete%szip?branch=master"
-		      (if (eq eglot-fsharp-server-runtime 'net-core)
-			  ".netcore."
-			".")))
+  (let* ((url (format "https://github.com/fsharp/FsAutoComplete/releases/download/%s/fsautocomplete%szip"
+					  eglot-fsharp-server-version
+					  (if (eq eglot-fsharp-server-runtime 'net-core)
+						  ".netcore."
+						".")))
 	 (exe (eglot-fsharp--path-to-server))
 	 (zip (concat (file-name-directory exe) "fsautocomplete.zip"))
 	 (gnutls-algorithm-priority


### PR DESCRIPTION
Fixes issue #245.

A request to change the link from a non-downloadable link to a downloadable release link in the Github repository.