### PR TITLE
Add the possibility to always install/autoupdate to  the latest version

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -1,6 +1,6 @@
 ;;; eglot-fsharp.el --- Lua eglot integration                     -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2019  Jürgen Hötzel
+;; Copyright (C) 2019-2020  Jürgen Hötzel
 
 ;; Author: Jürgen Hötzel <juergen@archlinux.org>
 ;; Package-Requires: ((eglot "1.4"))
@@ -41,11 +41,13 @@
   :risky t
   :type 'directory)
 
-(defcustom eglot-fsharp-server-version "0.41.1"
-  "FsAutoComplete version."
+(defcustom eglot-fsharp-server-version 'latest
+  "FsAutoComplete version to install or update."
   :group 'eglot-fsharp
   :risky t
-  :type 'string)
+  :type '(choice
+	  (const :tag "Latest release" latest)
+	  (string :tag "Version string")))
 
 (defcustom eglot-fsharp-server-runtime
   (if (executable-find "dotnet")
@@ -63,14 +65,48 @@
 			     "netcore/fsautocomplete.dll"
 			   "netframework/fsautocomplete.exe"))))
 
+;; cache to prevent repetitive queries
+(defvar eglot-fsharp--github-version nil "Latest fsautocomplete.exe GitHub version string.")
+
+(defun eglot-fsharp--github-version ()
+  "Return latest fsautocomplete.exe GitHub version string."
+  (or eglot-fsharp--github-version
+      (with-temp-buffer
+	(condition-case err
+	    (let ((json-object-type 'hash-table)
+		  (url-mime-accept-string "application/json"))
+	      (url-insert-file-contents "https://github.com/fsharp/fsautocomplete/releases/latest")
+	      (setq eglot-fsharp--github-version (gethash "tag_name" (json-parse-buffer))))
+	  (file-error
+	   (warn "fsautocomplete.exe update check:: %s" (error-message-string err)))))))
+
+(defun eglot-fsharp--installed-version ()
+  "Return version string of fsautocomplete."
+  (when (file-exists-p (eglot-fsharp--path-to-server))
+    (let* ((cmd (append (cdr (eglot-fsharp nil)) '("--version")))
+	   (version-line (concat (car (apply #'process-lines cmd )))))
+      (when (string-match "^FsAutoComplete \\([[:digit:].]+\\) " version-line)
+	(substring version-line (match-beginning 1) (match-end 1))
+	(match-string 1 version-line)))))
+
+(defun eglot-fsharp-current-version-p ()
+  "Return t if the installation is not outdated."
+  (when (file-exists-p (eglot-fsharp--path-to-server))
+    (if (eq eglot-fsharp-server-version 'latest)
+	(equal (eglot-fsharp--github-version) (eglot-fsharp--installed-version))
+      (equal eglot-fsharp-server-version (eglot-fsharp--installed-version)))))
+
 (defun eglot-fsharp--maybe-install ()
   "Downloads F# compiler service, and install in `eglot-fsharp-server-install-dir'."
   (make-directory (file-name-directory (eglot-fsharp--path-to-server)) t)
-  (let* ((url (format "https://github.com/fsharp/FsAutoComplete/releases/download/%s/fsautocomplete%szip"
-					  eglot-fsharp-server-version
-					  (if (eq eglot-fsharp-server-runtime 'net-core)
-						  ".netcore."
-						".")))
+  (let* ((version (if (eq eglot-fsharp-server-version 'latest)
+		      (eglot-fsharp--github-version)
+		    eglot-fsharp-server-version))
+	 (url (format "https://github.com/fsharp/FsAutoComplete/releases/download/%s/fsautocomplete%szip"
+		      version
+		      (if (eq eglot-fsharp-server-runtime 'net-core)
+			  ".netcore."
+			".")))
 	 (exe (eglot-fsharp--path-to-server))
 	 (zip (concat (file-name-directory exe) "fsautocomplete.zip"))
 	 (gnutls-algorithm-priority
@@ -79,20 +115,20 @@
 			  (>= libgnutls-version 30603)
 			  (version<= emacs-version "26.2"))
 		     "NORMAL:-VERS-TLS1.3"
-		   gnutls-algorithm-priority)))
-    (unless (file-exists-p exe)
+	    gnutls-algorithm-priority)))
+    (unless (eglot-fsharp-current-version-p)
       (url-copy-file url zip t)
-      ;; FIXME: Windows
+      ;; FIXME: Windows (unzip preinstalled?)
       (let ((default-directory (file-name-directory (eglot-fsharp--path-to-server))))
-	(unless (zerop (call-process "unzip" nil nil nil "-x" zip))
+	(unless (zerop (call-process "unzip" nil nil nil "-o" zip))
 	  (error "Failed to unzip %s" zip))
 	(delete-file zip)))))
 
  ;;;###autoload
 (defun eglot-fsharp (interactive)
-"Return `eglot' contact when FsAutoComplete is installed.
+  "Return `eglot' contact when FsAutoComplete is installed.
 Ensure FsAutoComplete is installed (when called INTERACTIVE)."
-  (unless (or (file-exists-p (eglot-fsharp--path-to-server)) (not interactive))
+  (when interactive
     (eglot-fsharp--maybe-install))
   (when (file-exists-p (eglot-fsharp--path-to-server))
     (cons 'eglot-fsautocomplete


### PR DESCRIPTION
Setting `eglot-fsharp-server-version' to 'latest will always install
the latest fsautocomplete version.

At every start of `eglot-fsharp' it is checked if the installed
version is outdated.

The github version check is done only once per session, so performance
is not affected too much.