### PR TITLE
Use json-read instead of json-parse-buffer

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -76,7 +76,8 @@
 	    (let ((json-object-type 'hash-table)
 		  (url-mime-accept-string "application/json"))
 	      (url-insert-file-contents "https://github.com/fsharp/fsautocomplete/releases/latest")
-	      (setq eglot-fsharp--github-version (gethash "tag_name" (json-parse-buffer))))
+	      (goto-char (point-min))
+	      (setq eglot-fsharp--github-version (gethash "tag_name" (json-read))))
 	  (file-error
 	   (warn "fsautocomplete.exe update check:: %s" (error-message-string err)))))))
 


### PR DESCRIPTION
This restores compatibility to Emacs 26.3. The native JSON functions
are only available since Emacs 27.1.

Issue introduced by #251 which uses native JSON