### PR TITLE
fsharp-mode: do not explicitly depend on eglot

### DIFF
--- a/Cask
+++ b/Cask
@@ -5,5 +5,6 @@
 (files "*.el")
 ;; FIXME: Use multiple packages: https://github.com/melpa/melpa#example-multiple-packages-in-one-repository ?
 (development
- (depends-on "buttercup"))
+ (depends-on "buttercup")
+ (depends-on "eglot"))
 

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -7,7 +7,7 @@
 ;;         2012-2014 Robin Neatherway <robin.neatherway@gmail.com>
 ;;         2017-2019 Jürgen Hötzel
 ;; Maintainer: Jürgen Hötzel
-;; Package-Requires: ((emacs "25")  (s "1.3.1") (dash "1.1.0") (eglot))
+;; Package-Requires: ((emacs "25")  (s "1.3.1") (dash "1.1.0"))
 ;; Keywords: languages
 ;; Version: 1.9.15
 


### PR DESCRIPTION
Currently `fsharp-mode` takes a hard dependency on `Eglot`, which is not desirable when other LSP system (like `lsp-mode`) has been in used.
Since user will need to take extra step of requiring `eglot-fsharp`, I think we should remove the dependency in header and instead let user install `eglot` and requiring `eglot-fsharp` by themselves