### PR TITLE
Fix interference with company-mode

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -201,8 +201,8 @@
           compile-command
           syntax-propertize-function
           company-backends
-          company-auto-complete
-          company-auto-complete-chars
+          company-auto-commit
+          company-auto-commit-chars
           company-require-match
           company-tooltip-align-annotations))
 


### PR DESCRIPTION
Company-mode has deprecated the variables company-auto-complete and
company-auto-complete-chars in favor of company-auto-commit and
company-auto-commit-chars for the same purposes.
The references to the old variable names are kept als deprecated aliases.
Creating local variables with the deprecated variable names seems to cause
issues when activating company-mode which complains with "Don't know how to make
a localized variable an alias".
This seems to prevent reliable auto-completion.