### PR TITLE
Replace dash.el with seq.el

### DIFF
--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -28,9 +28,6 @@
 
 ;;; Code:
 
-;; (require 'fsharp-mode)
-;; (require 'dash)
-
 (defgroup fsharp-ui nil
   "F# UI group for the defcustom interface."
   :prefix "fsharp-ui-"

--- a/fsharp-mode-util.el
+++ b/fsharp-mode-util.el
@@ -24,7 +24,6 @@
 ;; Boston, MA 02110-1301, USA.
 
 (with-no-warnings (require 'cl))
-(require 'dash)
 
 (defvar fsharp-ac-using-mono
   (case system-type

--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -7,7 +7,7 @@
 ;;         2012-2014 Robin Neatherway <robin.neatherway@gmail.com>
 ;;         2017-2019 Jürgen Hötzel
 ;; Maintainer: Jürgen Hötzel
-;; Package-Requires: ((emacs "25")  (s "1.3.1") (dash "1.1.0") (eglot))
+;; Package-Requires: ((emacs "25")  (s "1.3.1") (eglot))
 ;; Keywords: languages
 ;; Version: 1.9.15
 
@@ -35,7 +35,6 @@
 (require 'fsharp-mode-util)
 (require 'compile)
 (require 'project)
-(require 'dash)
 
 (defgroup fsharp nil
   "Support for the Fsharp programming language, <http://www.fsharp.net/>"
@@ -45,11 +44,11 @@
 ;;; Compilation
 
 (defvar fsharp-compile-command
-  (-any #'fsharp-mode--executable-find '("fsharpc" "fsc"))
+  (seq-some #'fsharp-mode--executable-find '("fsharpc" "fsc"))
   "The program used to compile F# source files.")
 
 (defvar fsharp-build-command
-  (-any #'fsharp-mode--msbuild-find '("msbuild" "xbuild"))
+  (seq-some #'fsharp-mode--msbuild-find '("msbuild" "xbuild"))
   "The command used to build F# projects and solutions.")
 
 ;;; ----------------------------------------------------------------------------


### PR DESCRIPTION
Emacs 25 ships with a sequence library named seq.el. This renders
dash.el completely obsolete.