### PR TITLE
Bump version

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -9,7 +9,7 @@
 ;; Maintainer: Jürgen Hötzel
 ;; Package-Requires: ((emacs "25")  (s "1.3.1") (eglot))
 ;; Keywords: languages
-;; Version: 1.9.15
+;; Version: 1.11-snapshot
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Fixes package-lint error:

eglot-fsharp.el:6:52 (package-lint-warning) Version dependency for fsharp-mode appears too high: try 1.9.15