### PR TITLE
Replace dash functions and fix byte-compile warnings

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -35,6 +35,8 @@
 (require 'fsharp-mode-util)
 (require 'compile)
 (require 'project)
+(require 'subr-x)
+(require 'seq)
 
 (defgroup fsharp nil
   "Support for the Fsharp programming language, <http://www.fsharp.net/>"
@@ -358,7 +360,7 @@ folders relative to DIR-OR-FILE."
 
 ;; Make project.el aware of fsharp projects
 (defun fsharp-mode-project-root (dir)
-  (-when-let (project-file (fsharp-mode/find-sln-or-fsproj dir))
+  (when-let (project-file (fsharp-mode/find-sln-or-fsproj dir))
     (cons 'fsharp (file-name-directory project-file))))
 
 (cl-defmethod project-roots ((project (head fsharp)))


### PR DESCRIPTION
This commit https://github.com/fsharp/emacs-fsharp-mode/commit/93b3e0036121eec298fe26f1267dd61944612b7a removed dash.el dependency but some dash functions still used. This PR replaces dash functions/macros with standard library's functions/macros.