### PR TITLE
Generic face for custom operators that contain pipe char sequence.

### DIFF
--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -171,6 +171,17 @@ with initial value INITVALUE and optional DOCSTRING."
   "<|\\{1,3\\}\\||\\{1,3\\}>"
   "Match the full range of pipe operators -- |>, ||>, |||>, etc.")
 
+(def-fsharp-compiled-var fsharp-custom-operator-with-pipe-regexp
+  (let ((op-chars "!%&\\*\\+\\-\\./<=>@\\^~") ;; all F# custom operator chars except for `|`
+        (backward-pipe "<|\\{1,3\\}")
+        (forward-pipe "|\\{1,3\\}>")
+        (alt "\\|"))
+    (concat "[" op-chars "|]*" backward-pipe "[" op-chars  "]+"
+        alt "[" op-chars "|]+" backward-pipe "[" op-chars  "]*"
+        alt "[" op-chars  "]*" forward-pipe  "[" op-chars "|]+"
+        alt "[" op-chars  "]+" forward-pipe  "[" op-chars "|]*"))
+  "Match operators that contains pipe sequence -- <|>, |>>, <<|, etc.")
+
 (def-fsharp-compiled-var fsharp-operator-case-regexp
   "\\s-+\\(|\\)[A-Za-z0-9_' ]"
   "Match literal | in contexts like match and type declarations.")
@@ -297,6 +308,7 @@ with initial value INITVALUE and optional DOCSTRING."
         nil nil
         (1 font-lock-function-name-face)
         (2 'fsharp-ui-operator-face)))
+      (,fsharp-custom-operator-with-pipe-regexp . 'fsharp-ui-generic-face)
       (,fsharp-operator-pipe-regexp . 'fsharp-ui-operator-face)
       (,fsharp-member-function-regexp 1 font-lock-function-name-face)
       (,fsharp-overload-operator-regexp 1 font-lock-function-name-face)

--- a/test/fsharp-mode-font-tests.el
+++ b/test/fsharp-mode-font-tests.el
@@ -1,9 +1,7 @@
 ;;; fsharp-mode-font-tests.el ---                         -*- lexical-binding: t; -*-
 
 (require 'buttercup)
-
 (require 'fsharp-mode)
-(require 'fsharp-mode-font)
 
 (defmacro with-highlighted (src &rest body)
   "Insert SRC in a temporary fsharp-mode buffer, apply syntax highlighting,
@@ -22,23 +20,23 @@ then run BODY."
 (defun str-face (op)
   (goto-char (point-min))
   (search-forward op)
-  (left-char)
+  (left-char 2)
   (face-at-point))
 
 (describe "When locking operators"
   (it "uses ui operator face for pipes"
     (with-highlighted "<<| |>> |> ||> |||> <| <|| <||| <|> <<|!"
-      (should (eq (str-face "|>") 'fsharp-ui-operator-face))
-      (should (eq (str-face "||>") 'fsharp-ui-operator-face))
-      (should (eq (str-face "|||>") 'fsharp-ui-operator-face))
-      (should (eq (str-face "<|") 'fsharp-ui-operator-face))
-      (should (eq (str-face "<||") 'fsharp-ui-operator-face))
-      (should (eq (str-face "<|||") 'fsharp-ui-operator-face)))))
+      (should (equal (str-face " |> ") 'fsharp-ui-operator-face))
+      (should (equal (str-face " ||> ") 'fsharp-ui-operator-face))
+      (should (equal (str-face " |||> ") 'fsharp-ui-operator-face))
+      (should (equal (str-face " <| ") 'fsharp-ui-operator-face))
+      (should (equal (str-face " <|| ") 'fsharp-ui-operator-face))
+      (should (equal (str-face " <||| ") 'fsharp-ui-operator-face)))))
 
 (describe "When locking operators"
   (it "uses ui generic face for custom operators containing pipes"
     (with-highlighted "<<| |>> |> ||> |||> <| <|| <||| <|> <<|!"
-      (should (eq (str-face "<<|") 'fsharp-ui-generic-face))
-      (should (eq (str-face "|>>") 'fsharp-ui-generic-face))
-      (should (eq (str-face "<|>") 'fsharp-ui-generic-face))
-      (should (eq (str-face "<<|!") 'fsharp-ui-generic-face)))))
+      (should (equal (str-face "<<| ") 'fsharp-ui-generic-face))
+      (should (equal (str-face " |>> ") 'fsharp-ui-generic-face))
+      (should (equal (str-face " <|> ") 'fsharp-ui-generic-face))
+      (should (equal (str-face " <<|!") 'fsharp-ui-generic-face)))))

--- a/test/fsharp-mode-font-tests.el
+++ b/test/fsharp-mode-font-tests.el
@@ -1,0 +1,44 @@
+;;; fsharp-mode-font-tests.el ---                         -*- lexical-binding: t; -*-
+
+(require 'buttercup)
+
+(require 'fsharp-mode)
+(require 'fsharp-mode-font)
+
+(defmacro with-highlighted (src &rest body)
+  "Insert SRC in a temporary fsharp-mode buffer, apply syntax highlighting,
+then run BODY."
+  `(with-temp-buffer
+     (fsharp-mode)
+     (insert ,src)
+     (goto-char (point-min))
+     ;; Ensure we've syntax-highlighted the whole buffer.
+     (if (fboundp 'font-lock-ensure)
+         (font-lock-ensure)
+       (with-no-warnings
+         (font-lock-fontify-buffer)))
+     ,@body))
+
+(defun str-face (op)
+  (goto-char (point-min))
+  (search-forward op)
+  (left-char)
+  (face-at-point))
+
+(describe "When locking operators"
+  (it "uses ui operator face for pipes"
+    (with-highlighted "<<| |>> |> ||> |||> <| <|| <||| <|> <<|!"
+      (should (eq (str-face "|>") 'fsharp-ui-operator-face))
+      (should (eq (str-face "||>") 'fsharp-ui-operator-face))
+      (should (eq (str-face "|||>") 'fsharp-ui-operator-face))
+      (should (eq (str-face "<|") 'fsharp-ui-operator-face))
+      (should (eq (str-face "<||") 'fsharp-ui-operator-face))
+      (should (eq (str-face "<|||") 'fsharp-ui-operator-face)))))
+
+(describe "When locking operators"
+  (it "uses ui generic face for custom operators containing pipes"
+    (with-highlighted "<<| |>> |> ||> |||> <| <|| <||| <|> <<|!"
+      (should (eq (str-face "<<|") 'fsharp-ui-generic-face))
+      (should (eq (str-face "|>>") 'fsharp-ui-generic-face))
+      (should (eq (str-face "<|>") 'fsharp-ui-generic-face))
+      (should (eq (str-face "<<|!") 'fsharp-ui-generic-face)))))


### PR DESCRIPTION
Currently, custom operators that contain pipe char sequence are colored partially.
Let's say we have operator `|>>` (monadic map in FSharpPlus and FParsec libs).
Part that contains pipe gets colored (`|>`), part that remains (`>`) stays default.
This PR sets all custom operators with pipe sequence to default.