### PR TITLE
fix: `//`-comments filled incorrectly (`//` not acting as prefix)

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -218,6 +218,7 @@ If set to t, the buffer will always be saved, silently."
         comment-end              ""
         comment-column           40
         comment-start-skip       "///* *"
+        adaptive-fill-regexp     "[ \t]*\\(//+[ \t]*\\)*"
         comment-indent-function  'fsharp-comment-indent-function
         indent-region-function   'fsharp-indent-region
         indent-line-function     'fsharp-indent-line


### PR DESCRIPTION
The problem is described [here](https://github.com/syl20bnr/spacemacs/issues/11326). I haven't been writing much F# lately but I found that `emacs-scala-mode` has the same problem and this fix works well for it, so I thought I would submit it here too.