### PR TITLE
Remove unneeded `files` directive

### DIFF
--- a/Cask
+++ b/Cask
@@ -2,9 +2,8 @@
 (source melpa)
 
 (package-file "fsharp-mode.el")
-(files "*.el")
+
 ;; FIXME: Use multiple packages: https://github.com/melpa/melpa#example-multiple-packages-in-one-repository ?
 (development
  (depends-on "buttercup")
  (depends-on "eglot"))
-


### PR DESCRIPTION
Remove unneeded `files` directive

`(files "*.el")` is not needed.

Before this commit:

    $ cask files
    eglot-fsharp.el
    fsharp-mode-font.el
    fsharp-mode-structure.el
    fsharp-mode-util.el
    fsharp-mode.el
    inf-fsharp-mode.el

After this commit:

    $ cask files
    eglot-fsharp.el
    fsharp-mode-font.el
    fsharp-mode-structure.el
    fsharp-mode-util.el
    fsharp-mode.el
    inf-fsharp-mode.el