### PR TITLE
Use cl-lib function instead of cl.el's one

### DIFF
--- a/inf-fsharp-mode.el
+++ b/inf-fsharp-mode.el
@@ -79,7 +79,7 @@ be sent from another buffer in fsharp mode.
   ;; use compilation mode to parse errors, but RET and C-cC-c should still be from comint-mode
   (compilation-minor-mode)
   (make-local-variable 'minor-mode-map-alist)
-  (setq minor-mode-map-alist (assq-delete-all 'compilation-minor-mode (copy-seq minor-mode-map-alist))))
+  (setq minor-mode-map-alist (assq-delete-all 'compilation-minor-mode (cl-copy-seq minor-mode-map-alist))))
 
 (defconst inferior-fsharp-buffer-subname "inferior-fsharp")
 (defconst inferior-fsharp-buffer-name


### PR DESCRIPTION
I got the following error when launching REPL.

```
inferior-fsharp-mode: Symbol’s function definition is void: copy-seq
```

cl.el is deprecated since Emacs 27 and newer Emacs doesn't load by default. This file already loads `cl-lib` so it should use cl-lib functions.
