### PR TITLE
Draft version of using .NET tool rather than zip file for .NET core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - 26.3
           - 27.1
           - 27.2
+          - 28.1
           - snapshot
     steps:
     - uses: purcell/setup-emacs@master

--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -51,6 +51,9 @@
           (const :tag "Latest release" latest)
           (string :tag "Version string")))
 
+(defcustom eglot-fsharp-server-verbose nil
+  "If non-nil include debug output in the server logs.")
+
 (defcustom eglot-fsharp-server-runtime
   (if (executable-find "dotnet")
       'net-core
@@ -64,11 +67,15 @@
   "Return FsAutoComplete path."
   (file-truename (concat eglot-fsharp-server-install-dir
                          (if (eq eglot-fsharp-server-runtime 'net-core)
-                             "netcore/fsautocomplete.dll"
+                             "netcore/fsautocomplete"
                            "netframework/fsautocomplete.exe"))))
 
 ;; cache to prevent repetitive queries
 (defvar eglot-fsharp--github-version nil "Latest fsautocomplete.exe GitHub version string.")
+
+(defun eglot-fsharp--clean-version (version)
+  "Remove any spurious prefix from the version string VERSION."
+  (string-trim-left version "[Vv]"))
 
 (defun eglot-fsharp--github-version ()
   "Return latest fsautocomplete.exe GitHub version string."
@@ -95,21 +102,16 @@
   "Return t if the installation is not outdated."
   (when (file-exists-p (eglot-fsharp--path-to-server))
     (if (eq eglot-fsharp-server-version 'latest)
-        (equal (eglot-fsharp--github-version) (eglot-fsharp--installed-version))
-      (equal eglot-fsharp-server-version (eglot-fsharp--installed-version)))))
+	(equal (eglot-fsharp--clean-version (eglot-fsharp--github-version))
+	       (eglot-fsharp--clean-version (eglot-fsharp--installed-version)))
+      (equal (eglot-fsharp--clean-version eglot-fsharp-server-version)
+	     (eglot-fsharp--clean-version (eglot-fsharp--installed-version))))))
 
-(defun eglot-fsharp--maybe-install ()
-  "Downloads F# compiler service, and install in `eglot-fsharp-server-install-dir'."
-  (make-directory (file-name-directory (eglot-fsharp--path-to-server)) t)
-  (let* ((version (if (eq eglot-fsharp-server-version 'latest)
-                      (eglot-fsharp--github-version)
-                    eglot-fsharp-server-version))
-         (url (format "https://github.com/fsharp/FsAutoComplete/releases/download/%s/fsautocomplete%szip"
-                      version
-                      (if (eq eglot-fsharp-server-runtime 'net-core)
-                          ".netcore."
-                        ".")))
-         (exe (eglot-fsharp--path-to-server))
+(defun eglot-fsharp--install-w32 (version)
+  "Download and install the full framework version of F# compiler service at version VERSION in `eglot-fsharp-server-install-dir'."
+  (let* ((url (format "https://github.com/fsharp/FsAutoComplete/releases/download/%s/fsautocomplete.zip"
+                      version))
+	 (exe (eglot-fsharp--path-to-server))
          (zip (concat (file-name-directory exe) "fsautocomplete.zip"))
          (gnutls-algorithm-priority
           (if (and (not gnutls-algorithm-priority)
@@ -117,8 +119,8 @@
                    (>= libgnutls-version 30603)
                    (version<= emacs-version "26.2"))
               "NORMAL:-VERS-TLS1.3"
-            gnutls-algorithm-priority)))
-    (unless (eglot-fsharp-current-version-p)
+            gnutls-algorithm-priority))))
+      (unless (eglot-fsharp-current-version-p)
       (url-copy-file url zip t)
       ;; FIXME: Windows (unzip preinstalled?)
       (let ((default-directory (file-name-directory (eglot-fsharp--path-to-server))))
@@ -129,21 +131,62 @@
 	    (if (file-directory-p file)
 		(chmod file #o755)
 	      (chmod file #o644)))))
-      (delete-file zip))))
+      (delete-file zip)))
+
+
+(defun eglot-fsharp--process-tool-action (response)
+  "Process the result of calling the dotnet tool installation returning RESPONSE code."
+  (if (eq response 1)
+      (let ((minibuffer-message-timeout 5)
+	    (msg (format "Error installing fsautocomplete see %s" (concat default-directory "error_output.txt")) ))
+	(minibuffer-message msg)
+	(error "Failed to install dotnet tool fsautocomplete"))))
+
+(defun eglot-fsharp--install-core (version)
+  "Download and install fsautocomplete as a dotnet tool at version VERSION in `eglot-fsharp-server-install-dir'."
+  (let ((vers (eglot-fsharp--clean-version version))
+	(default-directory (file-name-directory (eglot-fsharp--path-to-server))))
+    (unless (eglot-fsharp-current-version-p)
+      (if (file-exists-p (eglot-fsharp--path-to-server))
+	  (eglot-fsharp--process-tool-action	  (call-process "dotnet" nil '(nil
+									       "error_output.txt")
+								nil "tool" "uninstall"
+								"fsautocomplete" "--tool-path"
+								default-directory)))
+      (eglot-fsharp--process-tool-action (call-process "dotnet" nil '(nil "error_output.txt") nil
+						       "tool" "install" "fsautocomplete"
+						       "--tool-path" default-directory "--version"
+						       vers)))))
+
+(defun eglot-fsharp--maybe-install ()
+  "Downloads F# compiler service, and install in `eglot-fsharp-server-install-dir'."
+  (make-directory (file-name-directory (eglot-fsharp--path-to-server)) t)
+  (let* ((version (if (eq eglot-fsharp-server-version 'latest)
+                      (eglot-fsharp--github-version)
+                    eglot-fsharp-server-version)))
+  (if (eq eglot-fsharp-server-runtime 'net-core)
+      (eglot-fsharp--install-core version)
+    (eglot-fsharp--install-w32 version))))
 
  ;;;###autoload
-(defun eglot-fsharp (interactive)
+(defun eglot-fsharp
+    (interactive)
   "Return `eglot' contact when FsAutoComplete is installed.
 Ensure FsAutoComplete is installed (when called INTERACTIVE)."
-  (when interactive
-    (eglot-fsharp--maybe-install))
+  (when interactive (eglot-fsharp--maybe-install))
   (when (file-exists-p (eglot-fsharp--path-to-server))
-    (cons 'eglot-fsautocomplete
-          `(,(cond
-              ((eq eglot-fsharp-server-runtime 'net-core) "dotnet")
-              ((eq window-system 'w32) "")
-              (t "mono"))
-            ,(eglot-fsharp--path-to-server) "--background-service-enabled"))))
+    (let ((cmd-list (cond ((eq eglot-fsharp-server-runtime 'net-core)
+			   `(,(eglot-fsharp--path-to-server)))
+			  ((eq window-system 'w32)
+			   `("" , (eglot-fsharp--path-to-server)))
+			  (t `("mono" ,(eglot-fsharp--path-to-server)))))
+	  (arg-list (if eglot-fsharp-server-verbose
+			`("--background-service-enabled" "-v")
+            	        `("--background-service-enabled")
+		      )))
+      (cons 'eglot-fsautocomplete (append cmd-list arg-list)))))
+
+
 
 
 (defclass eglot-fsautocomplete (eglot-lsp-server) ()


### PR DESCRIPTION
This PR would solve [FSAutoComplete #883](https://github.com/fsharp/FsAutoComplete/issues/883) by installing FsAutoComplete as a .NET tool using .NET itself rather than downloading and expanding binary zip, which wasn't included on the last release of FsAutoComplete.

Issuing as a draft PR to see if folk are interested in this approach before I fix the tests, etc. I have confirmed that this will work for FsAutoComplete releases >= 0.49.0. 

Previous versions this could be made to work back to around FsAutoComplete ~ 0.42 but the name of the .NET tool changed so if that's desirable I'd need to conditionally check the version string and do a bit more testing.

