### PR TITLE
Use fsautocomplete.exe on Windows

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -67,7 +67,7 @@
   "Return FsAutoComplete path."
   (file-truename (concat eglot-fsharp-server-install-dir
                          (if (eq eglot-fsharp-server-runtime 'net-core)
-                             "netcore/fsautocomplete"
+                             (concat "netcore/fsautocomplete" (if (eq system-type 'windows-nt) ".exe" ""))
                            "netframework/fsautocomplete.exe"))))
 
 ;; cache to prevent repetitive queries


### PR DESCRIPTION
Hi,

After the last update, `eglot-fsharp--maybe-install` stopped working on my Windows setup. Turns out that was due to a missing `.exe` suffix. This fixes the problem for my setup, not sure if anyone else is actually running this mode on Windows anymore :)

Cheers!