### PR TITLE
Adds highlighting to applicative keyword

### DIFF
--- a/fsharp-mode-font.el
+++ b/fsharp-mode-font.el
@@ -236,7 +236,7 @@ with initial value INITVALUE and optional DOCSTRING."
 
 ;; F# keywords (3.4)
 (def-fsharp-compiled-var fsharp-ui-fsharp-threefour-keywords
-  '("abstract" "and" "as" "assert" "base" "begin"
+  '("abstract" "and" "and!" "as" "assert" "base" "begin"
     "class" "default" "delegate" "do" "do!" "done"
     "downcast" "downto" "elif" "else" "end"
     "exception" "extern" "false" "finally" "for" "fun"


### PR DESCRIPTION
In F# 5, a new keyword [`and!`](https://docs.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-50#applicative-computation-expressions) for applicatives was added to Computation Expressions.

How it was tested:

- nix-shell -p cask emacs python38 git which gnumake --pure
- make
- make run-fsharp-mode
- Checked highlighting on the scratch buffer after activating the mode