### PR TITLE
Generalize version string match

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -75,11 +75,11 @@
 
 (defun eglot-fsharp--latest-version ()
   "Return latest fsautocomplete.exe version."
-  (let ((process-environment (cons  "LANG=C" process-environment))) ;FIXME: Does this work in Windows
+  (let ((process-environment (cons  "LANG=C" process-environment))) ;FIXME: Doesn't work in Windows
     (if eglot-fsharp--latest-version
         eglot-fsharp--latest-version
       (setq eglot-fsharp--latest-version
-            (seq-some (lambda (s) (and (string-match "^Latest Version: \\(.*\\)$" s) (match-string 1 s)))
+            (seq-some (lambda (s) (and (string-match "^[[:alnum:]]* Version: \\(.*\\)$" s) (match-string 1 s)))
                       (process-lines "dotnet"  "tool" "search" "fsautocomplete" "--detail"))))))
 
 (defun eglot-fsharp--installed-version ()


### PR DESCRIPTION
LANG=C workaround doesn't work on Windows

Fixes issue using german locale
```
Aktuelle Version: 0.54.0
```
did not match.
