### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -52,7 +52,8 @@
           (string :tag "Version string")))
 
 (defcustom eglot-fsharp-server-verbose nil
-  "If non-nil include debug output in the server logs.")
+  "If non-nil include debug output in the server logs."
+  :type 'boolean)
 
 (defcustom eglot-fsharp-server-runtime
   (if (executable-find "dotnet")

--- a/fsharp-mode-structure.el
+++ b/fsharp-mode-structure.el
@@ -268,7 +268,7 @@ This function preserves point and mark."
 (defun fsharp-in-literal-p (&optional lim)
   "Return non-nil if point is in a Fsharp literal (a comment or
 string). The return value is specifically one of the symbols
-'comment or 'string. Optional argument LIM indicates the
+\\='comment or \\='string. Optional argument LIM indicates the
 beginning of the containing form, i.e. the limit on how far back
 to scan."
   ;; NOTE: Watch out for infinite recursion between this function and


### PR DESCRIPTION
- specify ':type' attribute for defcustom variables
- escape quotes in docstring

```
eglot-fsharp.el:54:12: Warning: defcustom for ‘eglot-fsharp-server-verbose’
    fails to specify type

fsharp-mode-structure.el:268:2: Warning: docstring has wrong usage of
    unescaped single quotes (use \= or different quoting)
```