### PR TITLE
Add Additional FSAutoComplete Parameters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         dotnet: [6.0.200]
         emacs_version:
-          - 27.1
           - 27.2
           - 28.1
+          - 28.2
           - snapshot
     steps:
     - uses: purcell/setup-emacs@master

--- a/README.org
+++ b/README.org
@@ -183,8 +183,8 @@ This project is maintained by the
 [[http://fsharp.org/][F# Software Foundation]], with the repository hosted
 on [[https://github.com/fsharp/emacs-fsharp-mode][GitHub]].
 
-Pull requests are welcome. Please run the test-suite with =make
-test= before submitting a pull request.
+Pull requests are welcome. Please run the test-suite with [Eldev](https://doublep.github.io/eldev/) =eldev -dtT test=
+before submitting a pull request.
 
 *** Maintainers
 

--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -55,6 +55,26 @@
   "Arguments for the fsautocomplete command when using `eglot-fsharp'."
   :type '(repeat string))
 
+(defcustom eglot-fsharp-fsautocomplete-args '(
+    :automaticWorkspaceInit t
+    :keywordsAutocomplete t
+    :externalAutocomplete nil
+    :linter t
+    :unionCaseStubGeneration t
+    :recordStubGeneration t
+    :interfaceStubGeneration t
+    :interfaceStubGenerationObjectIdentifier "this"
+    :unusedOpensAnalyzer t
+    :unusedDeclarationsAnalyzer t
+    :useSdkScripts t
+    :simplifyNameAnalyzer nil
+    :resolveNamespaces t
+    :enableReferenceCodeLens t)
+    "Arguments for the fsautocomplete initialization."
+    :group 'eglot-fsharp
+    :risky t
+  )
+
 (defun eglot-fsharp--path-to-server ()
   "Return FsAutoComplete path."
   (file-truename (concat eglot-fsharp-server-install-dir "netcore/fsautocomplete" (if (eq system-type 'windows-nt) ".exe" ""))))
@@ -133,21 +153,7 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
 
 (cl-defmethod eglot-initialization-options ((_server eglot-fsautocomplete))
   "Passes through required FsAutoComplete initialization options."
-  '(
-    :automaticWorkspaceInit t
-    :keywordsAutocomplete t
-    :externalAutocomplete nil
-    :linter t
-    :unionCaseStubGeneration t
-    :recordStubGeneration t
-    :interfaceStubGeneration t
-    :interfaceStubGenerationObjectIdentifier "this"
-    :unusedOpensAnalyzer t
-    :unusedDeclarationsAnalyzer t
-    :useSdkScripts t
-    :simplifyNameAnalyzer nil
-    :resolveNamespaces t
-    :enableReferenceCodeLens t))
+  `(:fSharp ,eglot-fsharp-fsautocomplete-args))
 
 ;; FIXME: this should be fixed in FsAutocomplete
 (cl-defmethod xref-backend-definitions :around ((_type symbol) _identifier)

--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -133,7 +133,21 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
 
 (cl-defmethod eglot-initialization-options ((_server eglot-fsautocomplete))
   "Passes through required FsAutoComplete initialization options."
-  '(:automaticWorkspaceInit t))
+  '(
+    :automaticWorkspaceInit t
+    :keywordsAutocomplete t
+    :externalAutocomplete nil
+    :linter t
+    :unionCaseStubGeneration t
+    :recordStubGeneration t
+    :interfaceStubGeneration t
+    :interfaceStubGenerationObjectIdentifier "this"
+    :unusedOpensAnalyzer t
+    :unusedDeclarationsAnalyzer t
+    :useSdkScripts t
+    :simplifyNameAnalyzer nil
+    :resolveNamespaces t
+    :enableReferenceCodeLens t))
 
 ;; FIXME: this should be fixed in FsAutocomplete
 (cl-defmethod xref-backend-definitions :around ((_type symbol) _identifier)

--- a/test/eglot-fsharp-integration-util.el
+++ b/test/eglot-fsharp-integration-util.el
@@ -147,7 +147,7 @@ Pass TIMEOUT to `eglot--with-timeout'."
 
 (defun eglot-fsharp--sniff-diagnostics (file-name-suffix)
   (eglot-fsharp--sniffing (:server-notifications s-notifs)
-                          (eglot-fsharp--wait-for (s-notifs 30)
+                          (eglot-fsharp--wait-for (s-notifs 20)
                                            (&key _id method params &allow-other-keys)
                                            (and
                                             (string= method "textDocument/publishDiagnostics")
@@ -155,7 +155,7 @@ Pass TIMEOUT to `eglot--with-timeout'."
 
 (defun eglot-fsharp--sniff-method (method-name)
   (eglot-fsharp--sniffing (:server-notifications s-notifs)
-                          (eglot-fsharp--wait-for (s-notifs 30)
+                          (eglot-fsharp--wait-for (s-notifs 20)
                                            (&key _id method params &allow-other-keys)
                                            (and
                                             (string= method method-name)))))

--- a/test/eglot-fsharp-integration-util.el
+++ b/test/eglot-fsharp-integration-util.el
@@ -147,7 +147,7 @@ Pass TIMEOUT to `eglot--with-timeout'."
 
 (defun eglot-fsharp--sniff-diagnostics (file-name-suffix)
   (eglot-fsharp--sniffing (:server-notifications s-notifs)
-                          (eglot-fsharp--wait-for (s-notifs 20)
+                          (eglot-fsharp--wait-for (s-notifs 30)
                                            (&key _id method params &allow-other-keys)
                                            (and
                                             (string= method "textDocument/publishDiagnostics")
@@ -155,7 +155,7 @@ Pass TIMEOUT to `eglot--with-timeout'."
 
 (defun eglot-fsharp--sniff-method (method-name)
   (eglot-fsharp--sniffing (:server-notifications s-notifs)
-                          (eglot-fsharp--wait-for (s-notifs 20)
+                          (eglot-fsharp--wait-for (s-notifs 30)
                                            (&key _id method params &allow-other-keys)
                                            (and
                                             (string= method method-name)))))

--- a/test/integration-tests.el
+++ b/test/integration-tests.el
@@ -61,11 +61,11 @@
     (with-current-buffer (eglot-fsharp--find-file-noselect "test/Test1/Error.fs")
       (flymake-mode t)
       (flymake-start)
+      (eglot-fsharp--sniff-diagnostics "test/Test1/Error.fs")
       (goto-char (point-min))
       (search-forward "nonexisting")
       (insert "x")
       (eglot--signal-textDocument/didChange)
-      (eglot-fsharp--sniff-diagnostics "test/Test1/Error.fs")
       (flymake-goto-next-error 1 '() t)
       (expect (face-at-point) :to-be 'flymake-error )))
   (it "provides completion"


### PR DESCRIPTION
[FsAutoComplate](https://github.com/fsharp/FsAutoComplete) readme specifies additional settings provided to init that allow linting, and auto expansion of records, interfaces, etc to be supplied to eglot. 

This PR adds those parameters. I'm tempted to make this customizable via a variable, although I'm torn if it should be a single customizable value with the entire propertylist or individual values per config setting. 