### PR TITLE
Update console app parameters

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -126,8 +126,8 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
   (when (file-exists-p (eglot-fsharp--path-to-server))
     (cons 'eglot-fsautocomplete (cons (eglot-fsharp--path-to-server)
                                       (if eglot-fsharp-server-verbose
-			                  `("--background-service-enabled" "-v")
-            	                        `("--background-service-enabled"))))))
+			                  `("--verbose" "--adaptive-lsp-server-enabled")
+            	                        `("--adaptive-lsp-server-enabled"))))))
 
 
 


### PR DESCRIPTION
The latest version of fsautocomplete removed the `--background-service` parameter which makes eglot crash on startup. This swaps to the updated parameter for lsp mode.


`--background-service` has been deprecated, switch to experimental adaptive lsp service

change the `-v` parameter to `--verbose` to align with the documentation
