### PR TITLE
disable self run mode hooks and let emacs run it

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -241,9 +241,7 @@ If set to t, the buffer will always be saved, silently."
 
   (let ((file (buffer-file-name)))
     (when file
-      (setq compile-command (fsharp-mode-choose-compile-command file))))
-
-  (run-hooks 'fsharp-mode-hook))
+      (setq compile-command (fsharp-mode-choose-compile-command file)))))
 
 (defun fsharp-mode-choose-compile-command (file)
   "Format an appropriate compilation command, depending on several factors:


### PR DESCRIPTION
Hello!

The hook is being run twice at the moment. This causes an issue for lsp-mode when we add `lsp-deferred` to the *fsharp-mode-hook* and the directory hasn't been added as a workspace yet; lsp-mode will prompt *twice* for the workspace initialization.

Currently, the workspace initialization is also failing for other reasons, but I've just submitted a [PR](https://github.com/emacs-lsp/lsp-mode/pull/3848) for that. 

Thanks!