### PR TITLE
Draft of FsProj Enhancements

### DIFF
--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -163,7 +163,7 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
 
 ;; FIXME: this should be fixed in FsAutocomplete
 (cl-defmethod xref-backend-definitions :around ((_type symbol) _identifier)
-  "FsAutoComplete breaks spec and and returns error instead of empty list."
+  "FsAutoComplete breaks spec and and return error instead of empty list."
   (if (eq major-mode 'fsharp-mode)
       (condition-case err
           (cl-call-next-method)
@@ -171,6 +171,15 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
          (not (equal (cadddr err) '(jsonrpc-error-message . "Could not find declaration")))))
     (when (cl-next-method-p)
       (cl-call-next-method))))
+
+;;; create buffer local settings for workspace reload based on mode hook
+
+(defun eglot-fsharp--set-workspace-args ()
+  "Set a buffer local variable with the workspace settings for eglot."
+  (make-local-variable 'eglot-workspace-configuration)
+  (let ((settings-json (json-serialize `(:fSharp ,eglot-fsharp-fsautocomplete-args))) )
+    (setq eglot-workspace-configuration settings-json ))
+  )
 
 (add-to-list 'eglot-server-programs `(fsharp-mode . eglot-fsharp))
 

--- a/eglot-fsharp.el
+++ b/eglot-fsharp.el
@@ -56,23 +56,66 @@
   :type '(repeat string))
 
 (defcustom eglot-fsharp-fsautocomplete-args '(
-    :automaticWorkspaceInit t
-    :keywordsAutocomplete t
-    :externalAutocomplete nil
-    :linter t
-    :unionCaseStubGeneration t
-    :recordStubGeneration t
-    :interfaceStubGeneration t
-    :interfaceStubGenerationObjectIdentifier "this"
-    :unusedOpensAnalyzer t
-    :unusedDeclarationsAnalyzer t
-    :useSdkScripts t
-    :simplifyNameAnalyzer nil
-    :resolveNamespaces t
-    :enableReferenceCodeLens t)
-    "Arguments for the fsautocomplete initialization."
-    :group 'eglot-fsharp
-    :risky t
+                                              :automaticWorkspaceInit t
+                                              :abstractClassStubGeneration t
+				              :abstractClassStubGenerationMethodBody
+				              "failwith \"Not Implemented\""
+				              :abstractClassStubGenerationObjectIdentifier "this"
+				              :addFsiWatcher nil
+				              :codeLenses (:references (:enabled t)
+							   :signature (:enabled t))
+				              :disableFailedProjectNotifications nil
+				              :dotnetRoot ""
+				              :enableAdaptiveLspServer t
+				              :enableAnalyzers nil
+				              :enableMSBuildProjectGraph nil
+				              :enableReferenceCodeLens t
+				              :excludeProjectDirectories [".git" "paket-files" ".fable" "packages" "node_modules"]
+				              :externalAutocomplete nil
+				              :fsac (:attachDebugger nil
+                                                                     :cachedTypeCheckCount 200
+				                                     :conserveMemory nil
+				                                     :dotnetArgs nil
+				                                     :netCoreDllPath ""
+				                                     :parallelReferenceResolution nil
+				                                     :silencedLogs nil)
+				              :fsiExtraParameters nil
+				              :fsiSdkFilePath ""
+				              :generateBinlog nil
+				              :indentationSize 4
+				              :inlayHints (:disableLongTooltip nil
+								               :enabled t
+								               :parameterNames t
+								               :typeAnnotations t)
+				              :inlineValues (:enabled nil
+							              :prefix "//")
+				              :interfaceStubGeneration t
+				              :interfaceStubGenerationMethodBody "failwith \"Not Implemented\""
+				              :interfaceStubGenerationObjectIdentifier "this"
+				              :keywordsAutocomplete t
+				              :lineLens (:enabled "replaceCodeLens"
+					                          :prefix " // ")
+				              :linter t
+				              :pipelineHints (:enabled t
+							               :prefix " // ")
+				              :recordStubGeneration t
+				              :recordStubGenerationBody "failwith \"Not Implemented\""
+				              :resolveNamespaces t
+				              :saveOnSendLastSelection nil
+				              :simplifyNameAnalyzer t
+				              :smartIndent nil
+				              :suggestGitignore t
+				              :suggestSdkScripts t
+				              :unionCaseStubGeneration t
+				              :unionCaseStubGenerationBody "failwith \"Not Implemented\""
+				              :unusedDeclarationsAnalyzer t
+				              :unusedOpensAnalyzer t
+				              :verboseLogging nil
+				              :workspaceModePeekDeepLevel 4
+				              :workspacePath "")
+  "Arguments for the fsautocomplete workspace configuration."
+  :group 'eglot-fsharp
+  :risky t
   )
 
 (defun eglot-fsharp--path-to-server ()
@@ -142,11 +185,21 @@
     (unless (eglot-fsharp-current-version-p version)
       (eglot-fsharp--install-core version))))
 
- ;;;###autoload
+;;; create buffer local settings for workspace reload based on mode hook
+
+(defun eglot-fsharp--set-workspace-args ()
+  "Set a buffer local variable with the workspace settings for eglot."
+  (make-local-variable 'eglot-workspace-configuration)
+  (let ((settings-json (json-serialize eglot-fsharp-fsautocomplete-args)) )
+    (setq eglot-workspace-configuration settings-json ))
+  )
+
+;;;###autoload
 (defun eglot-fsharp (interactive)
-    "Return `eglot' contact when FsAutoComplete is installed.
+  "Return `eglot' contact when FsAutoComplete is installed.
 Ensure FsAutoComplete is installed (when called INTERACTIVE)."
   (when interactive (eglot-fsharp--maybe-install))
+  (eglot-fsharp--set-workspace-args)
   (cons 'eglot-fsautocomplete
         (if (file-remote-p default-directory)
             `("sh" ,shell-command-switch ,(concat "cat|"  (mapconcat #'shell-quote-argument
@@ -159,7 +212,7 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
 
 (cl-defmethod eglot-initialization-options ((_server eglot-fsautocomplete))
   "Passes through required FsAutoComplete initialization options."
-  `(:fSharp ,eglot-fsharp-fsautocomplete-args))
+  eglot-fsharp-fsautocomplete-args)
 
 ;; FIXME: this should be fixed in FsAutocomplete
 (cl-defmethod xref-backend-definitions :around ((_type symbol) _identifier)
@@ -171,15 +224,6 @@ Ensure FsAutoComplete is installed (when called INTERACTIVE)."
          (not (equal (cadddr err) '(jsonrpc-error-message . "Could not find declaration")))))
     (when (cl-next-method-p)
       (cl-call-next-method))))
-
-;;; create buffer local settings for workspace reload based on mode hook
-
-(defun eglot-fsharp--set-workspace-args ()
-  "Set a buffer local variable with the workspace settings for eglot."
-  (make-local-variable 'eglot-workspace-configuration)
-  (let ((settings-json (json-serialize `(:fSharp ,eglot-fsharp-fsautocomplete-args))) )
-    (setq eglot-workspace-configuration settings-json ))
-  )
 
 (add-to-list 'eglot-server-programs `(fsharp-mode . eglot-fsharp))
 

--- a/fsproj-mode.el
+++ b/fsproj-mode.el
@@ -1,0 +1,95 @@
+;;; fsproj-mode.el -- fsproj-mode eglot fsharp integration                             -*- lexical-binding: t; -*-
+;; Copyright (C) 2023  Andrew McGuier
+
+;; Author: Andrew McGuier <amcguier@gmail.com>
+;; Package-Requires: ((emacs "27.1") (eglot "1.4") (jsonrpc "1.0.14"))
+;; Version: 1.10
+;; Keywords: languages
+;; URL: https://github.com/fsharp/emacs-fsharp-mode
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+
+;;; Code:
+(require 'dom)
+(require 'eglot)
+
+(defvar fsproj-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "u" 'fsproj-move-up)
+    (define-key map "d" 'fsproj-move-down) map)
+  "Local keymap for `fsproj-mode' buffers.")
+
+
+(defun fsproj--read-files (file-name)
+  "Pull out all the compileable files in an fsproj file in FILE-NAME."
+  (with-temp-buffer (insert-file-contents file-name)
+                    (mapcar (lambda (x)
+                              (list nil (vector (dom-attr x 'Include))))
+                            (dom-by-tag (libxml-parse-xml-region (point-min)
+                                                                 (point-max)) 'Compile))))
+
+(defun fsproj--set-tab-list ()
+  "Use the local fsproj-name variable to calculate the list of fsproj files to display."
+  (setq-local tabulated-list-entries (fsproj--read-files fsproj-name)))
+
+
+(defun fsproj-list-files () 
+  "Read an fsproj file contents and allow manipulating the file contents.
+This functionality requires eglot to function and should be called on an 
+fs file with an active eglot session."
+  (interactive)
+  (let ((current-server (eglot--current-server-or-lose))
+        (fsproj-nm (fsharp-mode/find-sln-or-fsproj (buffer-file-name))))
+    (pop-to-buffer (concat "*" (file-name-nondirectory fsproj-nm)  " info*"))
+    (fsproj-mode)
+    (setq-local current-eglot-server current-server)
+    (setq-local fsproj-name fsproj-nm)
+    (fsproj--set-tab-list)
+    (tabulated-list-print t)))
+
+(defun fsproj-move-up ()
+  "Move file up in the compilation order."
+  (interactive)
+  (let ((file-name (elt (tabulated-list-get-entry) 0)))
+    (if file-name (progn (jsonrpc-request current-eglot-server
+                                          :fsproj/moveFileUp `(:fsProj ,fsproj-name
+                                                                       :fileVirtualPath ,file-name))
+                         (tabulated-list-revert)
+                         (previous-line)))))
+
+(defun fsproj-move-down ()
+  "Move file up in the compilation order."
+  (interactive)
+  (let ((file-name (elt (tabulated-list-get-entry) 0)))
+    (if file-name (progn (jsonrpc-request current-eglot-server
+                                          :fsproj/moveFileDown `(:fsProj ,fsproj-name
+                                                                         :fileVirtualPath ,file-name))
+                         (tabulated-list-revert)
+                         (next-line)))))
+
+(define-derived-mode fsproj-mode tabulated-list-mode
+  "fsproj"
+  "Major mode for fsproj."
+  (setq-local tabulated-list-format [("File Name" 10 nil) ])
+  (tabulated-list-init-header))
+
+(add-to-list 'auto-mode-alist '("\\.fsproj info?\\'" . fsproj-mode))
+
+(add-hook 'tabulated-list-revert-hook 'fsproj--set-tab-list)
+
+(provide 'fsproj-mode)
+;;; fsproj-mode.el ends here


### PR DESCRIPTION
This PR is a (very) rough draft of some FsProj and eglot enhancements I've been playing with. 

I'd love to get some general feedback on the approach and see what folks appetite would be for bringing something like this in. 

#### Pain points this solves for my workflow

1.  Currently, when starting eglot in a multi-project workspace with a `sln` eglot uses the project integration and ends up finding the `fsproj` first, even if there's a `sln` file further up the directory tree, which means I end up running multiple copies of `FsAutoComplete` when editing client/server projects
2. When editing an fsproj file with the dotnet command line tools or manually, eglot/FsAutoComplete don't pickup the change, requiring me to kill/restart eglot to get completions on new files
3. Similar to '2.' when reordering files in an `fsproj` file during development I have to kill/restart eglot/FsAutoComplete for the changes to be detected 

#### General layout of my approach, and some reasoning. 

The solution file issue is straightforward, I've extended the project/sln search to first run a search for a `sln` file, and then to fallback to either an `fsproj` file if a `sln` file cannot be found [see here](https://github.com/fsharp/emacs-fsharp-mode/compare/master...amcguier:emacs-fsharp-mode:fsproj-enhancements#diff-ed8897e5966327969f25dbda3fd702e968f1b6b7ade8fb93086628d4cc4dc2e6R359)


For adding/removing `fs` files is accomplished via pretty straightforward modifications to `eglot-fsharp` itself [here](https://github.com/fsharp/emacs-fsharp-mode/compare/master...amcguier:emacs-fsharp-mode:fsproj-enhancements#diff-6d84e86fbc4daa458cc66c9b74388866a7496d604ea55a0a67d6dec84e84166cR197). Renaming is similar, although in that case I save the buffer first, and then open the alternative file once the operation is completed. 


The changing of the file order is a bit more complicated. I opted to create a new `fsproj-mode` because it simplifies the implementation of `tabulated-list-mode`, however this mode isn't intended to be accessed from an `fsproj` file, but rather launched from an `fs` file with eglot running, because it seems tricky to manage. You can open the buffer for with the command `fsproj-list-files` and then use u/d to move/change the file order.
