### PR TITLE
Enable nxml-mode for fsproj files

### DIFF
--- a/fsharp-mode.el
+++ b/fsharp-mode.el
@@ -114,6 +114,7 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.fs[iylx]?\\'" . fsharp-mode))
+(add-to-list 'auto-mode-alist '("\\.fsproj\\'" . nxml-mode))
 
 (defvar fsharp-mode-syntax-table nil
   "Syntax table in use in fsharp mode buffers.")


### PR DESCRIPTION
The `nxml-mode` is built-in and will enable editing the fsproj files like they're xml files.